### PR TITLE
Limit procs by default

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,7 +15,7 @@ fi
 PFLAG=""
 if [[ ${ENABLE_PARALLEL} == "true" ]]; then
 	echo "Running tests in parallel"
-	PFLAG="-p"
+	PFLAG="-procs=16"
 fi
 
 # Allow for flake retries

--- a/tests/platformalteration/parameters/parameters.go
+++ b/tests/platformalteration/parameters/parameters.go
@@ -23,7 +23,7 @@ var (
 		"app":                  "test",
 	}
 
-	NotRedHatRelease = "quay.io/jitesoft/nginx:1.23.3"
+	NotRedHatRelease = "quay.io/jitesoft/nginx:stable"
 )
 
 const (


### PR DESCRIPTION
Limited the number of default allowed procs to 16.

Switched the jitesoft/nginx image to use `stable` which is now multiarch:

https://quay.io/repository/jitesoft/nginx?tab=tags 