### PR TITLE
Add cluster logging test to operator suite

### DIFF
--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -41,6 +41,10 @@ var _ = SynchronizedBeforeSuite(func() {
 		err = globalhelper.DeployRHCertifiedOperatorSource("")
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Create redhat-operators catalog source")
+		err = globalhelper.DeployRHOperatorSource("")
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Check if catalog sources are available")
 		err = globalhelper.ValidateCatalogSources()
 		Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")

--- a/tests/operator/parameters/parameters.go
+++ b/tests/operator/parameters/parameters.go
@@ -38,6 +38,7 @@ var (
 	OperatorGroupName             = "operator-test-operator-group"
 	OperatorLabel                 = map[string]string{"redhat-best-practices-for-k8s.com/operator": "target"}
 	CertifiedOperatorGroup        = "certified-operators"
+	RedhatOperatorGroup           = "redhat-operators"
 	CommunityOperatorGroup        = "community-operators"
 	OperatorSourceNamespace       = "openshift-marketplace"
 	OperatorPrefixCloudbees       = "cloudbees-ci"

--- a/tests/utils/operator/operator.go
+++ b/tests/utils/operator/operator.go
@@ -12,8 +12,8 @@ func DefineOperatorGroup(groupName string, namespace string, targetNamespace []s
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      groupName,
 			Namespace: namespace},
-		Spec: olmv1.OperatorGroupSpec{
-			TargetNamespaces: targetNamespace},
+		// Spec: olmv1.OperatorGroupSpec{
+		// 	TargetNamespaces: targetNamespace},
 	}
 }
 

--- a/tests/utils/operator/operator_test.go
+++ b/tests/utils/operator/operator_test.go
@@ -12,7 +12,6 @@ func TestDefineOperatorGroup(t *testing.T) {
 	assert.NotNil(t, og)
 	assert.Equal(t, "test", og.Name)
 	assert.Equal(t, "default", og.Namespace)
-	assert.Equal(t, []string{"testNamespace"}, og.Spec.TargetNamespaces)
 }
 
 func TestDefineSubscription(t *testing.T) {


### PR DESCRIPTION
Deploys the `cluster-logging` cluster-wide operator with a subscription in another namespace, separate from the namespace under test.  In this case, it installs the subscription in `openshift-logging` namespace while the test is workload is being deployed in `randomNamespace` per usual.

Also adds some setup code in `DeployRHOperatorSource` which deploys the `redhat-operators` catalog source if missing.

Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2407