### PR TITLE
Add operator deployment back

### DIFF
--- a/tests/operator/helper/helper.go
+++ b/tests/operator/helper/helper.go
@@ -16,13 +16,18 @@ import (
 	utils "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/utils/operator"
 )
 
-func DeployTestOperatorGroup(namespace string) error {
+func DeployTestOperatorGroup(namespace string, clusterWide bool) error {
 	if globalhelper.IsOperatorGroupInstalled(tsparams.OperatorGroupName,
 		namespace) != nil {
+		targetNamespaces := []string{namespace}
+		if clusterWide {
+			targetNamespaces = []string{}
+		}
+
 		return globalhelper.DeployOperatorGroup(namespace,
 			utils.DefineOperatorGroup(tsparams.OperatorGroupName,
 				namespace,
-				[]string{namespace}),
+				targetNamespaces),
 		)
 	}
 

--- a/tests/operator/tests/operator_crd_openapi_schema.go
+++ b/tests/operator/tests/operator_crd_openapi_schema.go
@@ -32,7 +32,7 @@ var _ = Describe("Operator crd-openapi-schema", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Deploy operator group")
-		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		By("Deploy openvino operator for testing")

--- a/tests/operator/tests/operator_crd_versioning.go
+++ b/tests/operator/tests/operator_crd_versioning.go
@@ -32,7 +32,7 @@ var _ = Describe("Operator crd-versioning,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Deploy operator group")
-		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		By("Deploy openvino operator for testing")

--- a/tests/operator/tests/operator_install_source.go
+++ b/tests/operator/tests/operator_install_source.go
@@ -39,7 +39,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 
 		// Install 3 separate operators for testing
 		By("Deploy operator group")
-		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 	})
 
@@ -61,7 +61,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create fake operator group for cluster-logging operator")
-		err = tshelper.DeployTestOperatorGroup(openshiftLoggingNamespace)
+		err = tshelper.DeployTestOperatorGroup(openshiftLoggingNamespace, true)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		DeferCleanup(func() {
@@ -116,6 +116,25 @@ var _ = Describe("Operator install-source,", Serial, func() {
 
 	// 66142
 	It("one operator installed with OLM", func() {
+		By("Deploy cloudbees-ci operator for testing")
+		err := tshelper.DeployOperatorSubscription(
+			"cloudbees-ci",
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			"",
+			v1alpha1.ApprovalAutomatic,
+		)
+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.OperatorPrefixCloudbees)
+
+		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixCloudbees,
+			randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.OperatorPrefixCloudbees+
+			" is not ready")
+
 		By("Label operator")
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -126,7 +145,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			ErrorLabelingOperatorStr+tsparams.OperatorPrefixCloudbees)
 
 		By("Start test")
-		err := globalhelper.LaunchTests(
+		err = globalhelper.LaunchTests(
 			tsparams.CertsuiteOperatorInstallSource,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			randomReportDir,
@@ -142,6 +161,24 @@ var _ = Describe("Operator install-source,", Serial, func() {
 
 	// 66143
 	It("one operator not installed with OLM [negative]", func() {
+		By("Deploy openvino operator for testing")
+		err := tshelper.DeployOperatorSubscription(
+			"ovms-operator",
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			"",
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.OperatorPrefixOpenvino)
+
+		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixOpenvino,
+			randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.OperatorPrefixOpenvino+
+			" is not ready")
+
 		By("Label operator")
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -152,7 +189,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			ErrorLabelingOperatorStr+tsparams.OperatorPrefixOpenvino)
 
 		By("Delete operator's subscription")
-		err := globalhelper.DeleteSubscription(randomNamespace,
+		err = globalhelper.DeleteSubscription(randomNamespace,
 			tsparams.SubscriptionNameOpenvino)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -173,6 +210,38 @@ var _ = Describe("Operator install-source,", Serial, func() {
 
 	// 66144
 	It("two operators, both installed with OLM", func() {
+		By("Deploy cloudbees-ci operator for testing")
+		err := tshelper.DeployOperatorSubscription(
+			"cloudbees-ci",
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			"",
+			v1alpha1.ApprovalAutomatic,
+		)
+
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.OperatorPrefixCloudbees)
+
+		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixCloudbees,
+			randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.OperatorPrefixCloudbees+
+			" is not ready")
+
+		By("Deploy anchore-engine operator for testing")
+		err = tshelper.DeployOperatorSubscription(
+			"anchore-engine",
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			"",
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.OperatorPrefixAnchore)
+
 		By("Label operators")
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -191,7 +260,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			ErrorLabelingOperatorStr+tsparams.OperatorPrefixAnchore)
 
 		By("Start test")
-		err := globalhelper.LaunchTests(
+		err = globalhelper.LaunchTests(
 			tsparams.CertsuiteOperatorInstallSource,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
 			randomReportDir,
@@ -207,6 +276,37 @@ var _ = Describe("Operator install-source,", Serial, func() {
 
 	// 66145
 	It("two operators, one not installed with OLM [negative]", func() {
+		By("Deploy openvino operator for testing")
+		err := tshelper.DeployOperatorSubscription(
+			"ovms-operator",
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			"",
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.OperatorPrefixOpenvino)
+
+		err = tshelper.WaitUntilOperatorIsReady(tsparams.OperatorPrefixOpenvino,
+			randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.OperatorPrefixOpenvino+
+			" is not ready")
+
+		By("Deploy anchore-engine operator for testing")
+		err = tshelper.DeployOperatorSubscription(
+			"anchore-engine",
+			"alpha",
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			"",
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.OperatorPrefixAnchore)
+
 		By("Label operators")
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
@@ -225,7 +325,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 			ErrorLabelingOperatorStr+tsparams.OperatorPrefixOpenvino)
 
 		By("Delete operator's subscription")
-		err := globalhelper.DeleteSubscription(randomNamespace,
+		err = globalhelper.DeleteSubscription(randomNamespace,
 			tsparams.SubscriptionNameOpenvino)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/operator/tests/operator_install_status.go
+++ b/tests/operator/tests/operator_install_status.go
@@ -32,7 +32,7 @@ var _ = Describe("Operator install-source,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Deploy operator group")
-		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		By("Deploy cloudbees-ci operator for testing")

--- a/tests/operator/tests/operator_install_status_no_privileges.go
+++ b/tests/operator/tests/operator_install_status_no_privileges.go
@@ -32,7 +32,7 @@ var _ = Describe("Operator install-status-no-privileges,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Deploy operator group")
-		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		// cloudbees operator has clusterPermissions but no resourceNames

--- a/tests/operator/tests/operator_non_root.go
+++ b/tests/operator/tests/operator_non_root.go
@@ -45,7 +45,7 @@ var _ = Describe("Operator pods non-root", func() {
 	It("Operator pods should not run as root [negative]", func() {
 		// Deploy an operator that runs as root
 		By("Deploy operator group")
-		err := tshelper.DeployTestOperatorGroup(randomNamespace)
+		err := tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)

--- a/tests/operator/tests/operator_pod_automount_token.go
+++ b/tests/operator/tests/operator_pod_automount_token.go
@@ -33,7 +33,7 @@ var _ = Describe("Operator pods automount token", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Deploy operator group")
-		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 	})
 
@@ -48,7 +48,7 @@ var _ = Describe("Operator pods automount token", func() {
 		// contains a service account that leaves the SA default/nil and that defaults to true.
 		// The SA should contain a automountServiceAccountToken field that is set explicitly to false.
 		By("Deploy operator group")
-		err := tshelper.DeployTestOperatorGroup(randomNamespace)
+		err := tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)

--- a/tests/operator/tests/operator_read_only_filesystem.go
+++ b/tests/operator/tests/operator_read_only_filesystem.go
@@ -33,7 +33,7 @@ var _ = Describe("Operator pods read only filesystem", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Deploy operator group")
-		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 	})
 
@@ -51,7 +51,7 @@ var _ = Describe("Operator pods read only filesystem", func() {
 	It("Operator pods should not have read-only filesystem [negative]", func() {
 		// Deploy an operator that has read-only filesystem
 		By("Deploy operator group")
-		err := tshelper.DeployTestOperatorGroup(randomNamespace)
+		err := tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)

--- a/tests/operator/tests/operator_run_as_userid.go
+++ b/tests/operator/tests/operator_run_as_userid.go
@@ -41,7 +41,7 @@ var _ = Describe("Operator pods have runAs userid", func() {
 	It("Operator pods should have runAs userid", func() {
 		// Deploy an operator that has runAs userid
 		By("Deploy operator group")
-		err := tshelper.DeployTestOperatorGroup(randomNamespace)
+		err := tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)

--- a/tests/operator/tests/operator_semantic_versioning.go
+++ b/tests/operator/tests/operator_semantic_versioning.go
@@ -33,7 +33,7 @@ var _ = Describe("Operator semantic-versioning,", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Deploy operator group")
-		err = tshelper.DeployTestOperatorGroup(randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		By("Deploy openvino operator for testing")

--- a/tests/utils/operator/operator.go
+++ b/tests/utils/operator/operator.go
@@ -12,8 +12,8 @@ func DefineOperatorGroup(groupName string, namespace string, targetNamespace []s
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      groupName,
 			Namespace: namespace},
-		// Spec: olmv1.OperatorGroupSpec{
-		// 	TargetNamespaces: targetNamespace},
+		Spec: olmv1.OperatorGroupSpec{
+			TargetNamespaces: targetNamespace},
 	}
 }
 


### PR DESCRIPTION
Add the logic back to deploy the operators into each test case that needs them, and then add a boolean for targetNamespaces for operator group.