### PR TITLE
Update eco-goinfra to latest commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
-	github.com/openshift-kni/eco-goinfra v0.0.0-20240924153415-499674241c62
+	github.com/openshift-kni/eco-goinfra v0.0.0-20240925123158-d27bef1a25a6
 	github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87
 	github.com/operator-framework/api v0.27.0
 	github.com/operator-framework/operator-lifecycle-manager v0.28.0
@@ -126,7 +126,6 @@ require (
 
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
-	github.com/openshift-kni/eco-goinfra => github.com/openshift-kni/eco-goinfra v0.0.0-20240924153415-499674241c62
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20240823112050-2b42490270d8
 	k8s.io/client-go => k8s.io/client-go v0.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/onsi/gomega v1.33.0/go.mod h1:+925n5YtiFsLzzafLUHzVMBpvvRAzrydIBiSIxj
 github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
 github.com/onsi/gomega v1.34.2 h1:pNCwDkzrsv7MS9kpaQvVb1aVLahQXyJ/Tv5oAZMI3i8=
 github.com/onsi/gomega v1.34.2/go.mod h1:v1xfxRgk0KIsG+QOdm7p8UosrOzPYRo60fd3B/1Dukc=
-github.com/openshift-kni/eco-goinfra v0.0.0-20240924153415-499674241c62 h1:aqJiR2DPHHEGkvxZVfRceMxke6Gq5oap1vB3STRur6E=
-github.com/openshift-kni/eco-goinfra v0.0.0-20240924153415-499674241c62/go.mod h1:yWno/75XOopIj/GlMgvm+dye+cwbaMQBVek1XNGl+SI=
+github.com/openshift-kni/eco-goinfra v0.0.0-20240925123158-d27bef1a25a6 h1:P/4sAT/52g7ngBcgpeGmI6KdpaKM0+4XXYORjopi6Jw=
+github.com/openshift-kni/eco-goinfra v0.0.0-20240925123158-d27bef1a25a6/go.mod h1:yWno/75XOopIj/GlMgvm+dye+cwbaMQBVek1XNGl+SI=
 github.com/openshift/api v0.0.0-20240823112050-2b42490270d8 h1:1Dgn1a5HWbNZK2zYEZXnjM/4KAe3xWekQrl0sYPNWpA=
 github.com/openshift/api v0.0.0-20240823112050-2b42490270d8/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEconE+1IKmIgCOof/Len5ceG6H1pk43yv5U=

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/rbac/clusterrole.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/rbac/clusterrole.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,9 +19,9 @@ ClusterRoleBuilder provides struct for clusterrole object
 */
 type ClusterRoleBuilder struct {
 	// Clusterrole definition. Used to create a clusterrole object.
-	Definition *v1.ClusterRole
+	Definition *rbacv1.ClusterRole
 	// Created clusterrole object
-	Object *v1.ClusterRole
+	Object *rbacv1.ClusterRole
 	// Used in functions that define or mutate clusterrole definition. errorMsg is processed before clusterrole
 	// object is created.
 	errorMsg  string
@@ -32,7 +32,7 @@ type ClusterRoleBuilder struct {
 type ClusterRoleAdditionalOptions func(builder *ClusterRoleBuilder) (*ClusterRoleBuilder, error)
 
 // NewClusterRoleBuilder creates new instance of ClusterRoleBuilder.
-func NewClusterRoleBuilder(apiClient *clients.Settings, name string, rule v1.PolicyRule) *ClusterRoleBuilder {
+func NewClusterRoleBuilder(apiClient *clients.Settings, name string, rule rbacv1.PolicyRule) *ClusterRoleBuilder {
 	glog.V(100).Infof(
 		"Initializing new clusterrole structure with the following params: "+
 			"name: %s, policy rule: %v",
@@ -40,7 +40,7 @@ func NewClusterRoleBuilder(apiClient *clients.Settings, name string, rule v1.Pol
 
 	builder := ClusterRoleBuilder{
 		apiClient: apiClient,
-		Definition: &v1.ClusterRole{
+		Definition: &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
@@ -53,13 +53,13 @@ func NewClusterRoleBuilder(apiClient *clients.Settings, name string, rule v1.Pol
 		builder.errorMsg = "clusterrole 'name' cannot be empty"
 	}
 
-	builder.WithRules([]v1.PolicyRule{rule})
+	builder.WithRules([]rbacv1.PolicyRule{rule})
 
 	return &builder
 }
 
 // WithRules appends additional rules to the clusterrole definition.
-func (builder *ClusterRoleBuilder) WithRules(rules []v1.PolicyRule) *ClusterRoleBuilder {
+func (builder *ClusterRoleBuilder) WithRules(rules []rbacv1.PolicyRule) *ClusterRoleBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -137,7 +137,7 @@ func PullClusterRole(apiClient *clients.Settings, name string) (*ClusterRoleBuil
 
 	builder := ClusterRoleBuilder{
 		apiClient: apiClient,
-		Definition: &v1.ClusterRole{
+		Definition: &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/rbac/clusterrolebinding.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/rbac/clusterrolebinding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	"golang.org/x/exp/slices"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,9 +17,9 @@ import (
 // containing connection to the cluster and the clusterrolebinding definitions.
 type ClusterRoleBindingBuilder struct {
 	// Clusterrolebinding definition. Used to create a clusterrolebinding object.
-	Definition *v1.ClusterRoleBinding
+	Definition *rbacv1.ClusterRoleBinding
 	// Created clusterrolebinding object
-	Object *v1.ClusterRoleBinding
+	Object *rbacv1.ClusterRoleBinding
 	// Used in functions that define or mutate clusterrolebinding definition.
 	// errorMsg is processed before the clusterrolebinding object is created.
 	errorMsg  string
@@ -31,7 +31,7 @@ type ClusterRoleBindingAdditionalOptions func(builder *ClusterRoleBindingBuilder
 
 // NewClusterRoleBindingBuilder creates a new instance of ClusterRoleBindingBuilder.
 func NewClusterRoleBindingBuilder(
-	apiClient *clients.Settings, name, clusterRole string, subject v1.Subject) *ClusterRoleBindingBuilder {
+	apiClient *clients.Settings, name, clusterRole string, subject rbacv1.Subject) *ClusterRoleBindingBuilder {
 	glog.V(100).Infof(
 		"Initializing new clusterrolebinding structure with the following params: "+
 			"name: %s, clusterrole: %s, subject %v",
@@ -39,11 +39,11 @@ func NewClusterRoleBindingBuilder(
 
 	builder := ClusterRoleBindingBuilder{
 		apiClient: apiClient,
-		Definition: &v1.ClusterRoleBinding{
+		Definition: &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
-			RoleRef: v1.RoleRef{
+			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Name:     clusterRole,
 				Kind:     "ClusterRole",
@@ -51,7 +51,7 @@ func NewClusterRoleBindingBuilder(
 		},
 	}
 
-	builder.WithSubjects([]v1.Subject{subject})
+	builder.WithSubjects([]rbacv1.Subject{subject})
 
 	if name == "" {
 		glog.V(100).Infof("The name of the clusterrolebinding is empty")
@@ -63,7 +63,7 @@ func NewClusterRoleBindingBuilder(
 }
 
 // WithSubjects appends additional subjects to clusterrolebinding definition.
-func (builder *ClusterRoleBindingBuilder) WithSubjects(subjects []v1.Subject) *ClusterRoleBindingBuilder {
+func (builder *ClusterRoleBindingBuilder) WithSubjects(subjects []rbacv1.Subject) *ClusterRoleBindingBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -136,7 +136,7 @@ func PullClusterRoleBinding(apiClient *clients.Settings, name string) (*ClusterR
 
 	builder := ClusterRoleBindingBuilder{
 		apiClient: apiClient,
-		Definition: &v1.ClusterRoleBinding{
+		Definition: &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/rbac/role.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/rbac/role.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,9 +15,9 @@ import (
 // RoleBuilder provides a struct for role object containing connection to the cluster and the role definitions.
 type RoleBuilder struct {
 	// Role definition. Used to create a role object
-	Definition *v1.Role
+	Definition *rbacv1.Role
 	// Created role object
-	Object *v1.Role
+	Object *rbacv1.Role
 
 	// Used in functions that define or mutate role definition. errorMsg is processed
 	// before the role object is created
@@ -29,14 +29,14 @@ type RoleBuilder struct {
 type RoleAdditionalOptions func(builder *RoleBuilder) (*RoleBuilder, error)
 
 // NewRoleBuilder create a new instance of RoleBuilder.
-func NewRoleBuilder(apiClient *clients.Settings, name, nsname string, rule v1.PolicyRule) *RoleBuilder {
+func NewRoleBuilder(apiClient *clients.Settings, name, nsname string, rule rbacv1.PolicyRule) *RoleBuilder {
 	glog.V(100).Infof(
 		"Initializing new role structure with the following params: "+
 			"name: %s, namespace: %s, rule %v", name, nsname, rule)
 
 	builder := &RoleBuilder{
 		apiClient: apiClient,
-		Definition: &v1.Role{
+		Definition: &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
@@ -60,13 +60,13 @@ func NewRoleBuilder(apiClient *clients.Settings, name, nsname string, rule v1.Po
 		return builder
 	}
 
-	builder.WithRules([]v1.PolicyRule{rule})
+	builder.WithRules([]rbacv1.PolicyRule{rule})
 
 	return builder
 }
 
 // WithRules adds the specified PolicyRule to the Role.
-func (builder *RoleBuilder) WithRules(rules []v1.PolicyRule) *RoleBuilder {
+func (builder *RoleBuilder) WithRules(rules []rbacv1.PolicyRule) *RoleBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -155,7 +155,7 @@ func PullRole(apiClient *clients.Settings, name, nsname string) (*RoleBuilder, e
 
 	builder := RoleBuilder{
 		apiClient: apiClient,
-		Definition: &v1.Role{
+		Definition: &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,

--- a/vendor/github.com/openshift-kni/eco-goinfra/pkg/rbac/rolebinding.go
+++ b/vendor/github.com/openshift-kni/eco-goinfra/pkg/rbac/rolebinding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	"golang.org/x/exp/slices"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,9 +17,9 @@ import (
 // to the cluster RoleBinding definition.
 type RoleBindingBuilder struct {
 	// Rolebinding definition. Used to create rolebinding object
-	Definition *v1.RoleBinding
+	Definition *rbacv1.RoleBinding
 	// Created rolebinding object
-	Object *v1.RoleBinding
+	Object *rbacv1.RoleBinding
 
 	// Used in functions that define or mutate rolebinding definition. errorMsg is processed
 	// before the rolebinding object is created
@@ -33,19 +33,19 @@ type RoleBindingAdditionalOptions func(builder *RoleBindingBuilder) (*RoleBindin
 // NewRoleBindingBuilder creates new instance of RoleBindingBuilder.
 func NewRoleBindingBuilder(apiClient *clients.Settings,
 	name, nsname, role string,
-	subject v1.Subject) *RoleBindingBuilder {
+	subject rbacv1.Subject) *RoleBindingBuilder {
 	glog.V(100).Infof(
 		"Initializing new rolebinding structure with the following params: "+
 			"name: %s, namespace: %s, role: %s, subject %v", name, nsname, role, subject)
 
 	builder := RoleBindingBuilder{
 		apiClient: apiClient,
-		Definition: &v1.RoleBinding{
+		Definition: &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
-			RoleRef: v1.RoleRef{
+			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Name:     role,
 				Kind:     "Role",
@@ -65,13 +65,13 @@ func NewRoleBindingBuilder(apiClient *clients.Settings,
 		builder.errorMsg = "RoleBinding 'nsname' cannot be empty"
 	}
 
-	builder.WithSubjects([]v1.Subject{subject})
+	builder.WithSubjects([]rbacv1.Subject{subject})
 
 	return &builder
 }
 
 // WithSubjects adds specified Subject to the RoleBinding.
-func (builder *RoleBindingBuilder) WithSubjects(subjects []v1.Subject) *RoleBindingBuilder {
+func (builder *RoleBindingBuilder) WithSubjects(subjects []rbacv1.Subject) *RoleBindingBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -142,7 +142,7 @@ func PullRoleBinding(apiClient *clients.Settings, name, nsname string) (*RoleBin
 
 	builder := RoleBindingBuilder{
 		apiClient: apiClient,
-		Definition: &v1.RoleBinding{
+		Definition: &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -269,7 +269,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift-kni/eco-goinfra v0.0.0-20240924153415-499674241c62 => github.com/openshift-kni/eco-goinfra v0.0.0-20240924153415-499674241c62
+# github.com/openshift-kni/eco-goinfra v0.0.0-20240925123158-d27bef1a25a6
 ## explicit; go 1.22
 github.com/openshift-kni/eco-goinfra/pkg/clients
 github.com/openshift-kni/eco-goinfra/pkg/daemonset
@@ -920,6 +920,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
-# github.com/openshift-kni/eco-goinfra => github.com/openshift-kni/eco-goinfra v0.0.0-20240924153415-499674241c62
 # github.com/openshift/api => github.com/openshift/api v0.0.0-20240823112050-2b42490270d8
 # k8s.io/client-go => k8s.io/client-go v0.31.0


### PR DESCRIPTION
Remove `eco-goinfra` from the replace section of the go.mod so dependabot can update this.