### PR TITLE
operator: add test for multiple-same-operators

### DIFF
--- a/tests/affiliatedcertification/helper/helper.go
+++ b/tests/affiliatedcertification/helper/helper.go
@@ -99,10 +99,10 @@ func GetCsvByPrefix(prefixCsvName string, namespace string) (*v1alpha1.ClusterSe
 	return &neededCSV, nil
 }
 
-func DeployOperatorSubscription(operatorPackage, channel, namespace, group,
+func DeployOperatorSubscription(subscriptionName, operatorPackage, channel, namespace, group,
 	sourceNamespace, startingCSV string, installApproval v1alpha1.Approval) error {
 	operatorSubscription := utils.DefineSubscription(
-		operatorPackage+"-subscription",
+		subscriptionName+"-subscription",
 		namespace,
 		channel,
 		operatorPackage,

--- a/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
@@ -54,6 +54,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 		// nginx-ingress-operator: in certified-operators group and version is certified
 		err = tshelper.DeployOperatorSubscription(
 			tsparams.CertifiedOperatorPrefixNginx,
+			tsparams.CertifiedOperatorPrefixNginx,
 			channel,
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,
@@ -91,6 +92,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 
 		By("Deploy sriov-fec operator with uncertified version")
 		err = tshelper.DeployOperatorSubscription(
+			tsparams.UncertifiedOperatorPrefixSriov,
 			tsparams.UncertifiedOperatorPrefixSriov,
 			"stable",
 			randomNamespace,

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -36,6 +36,7 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 		// cockroachdb: not in certified-operators group in catalog, for negative test cases
 		err := tshelper.DeployOperatorSubscription(
 			"cockroachdb",
+			"cockroachdb",
 			"stable-v6.x",
 			randomNamespace,
 			tsparams.CommunityOperatorGroup,
@@ -68,6 +69,7 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 		// cockroachdb-certified operator: in certified-operators group and version is certified
 		err = tshelper.DeployOperatorSubscription(
 			"cockroachdb-certified",
+			"cockroachdb-certified",
 			channel,
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,
@@ -99,6 +101,7 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 		By(fmt.Sprintf("Deploy nginx-ingress-operator.v%s for testing", version))
 		// nginx-ingress-operator: in certified-operators group and version is certified
 		err = tshelper.DeployOperatorSubscription(
+			tsparams.CertifiedOperatorPrefixNginx,
 			tsparams.CertifiedOperatorPrefixNginx,
 			channel,
 			randomNamespace,

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -98,16 +98,16 @@ func BeforeEachSetupWithRandomNamespace(incomingNamespace string) (randomNamespa
 }
 
 func AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, randomConfigDir string, waitingTime time.Duration) {
-	// logfile := "certsuite.log"
-	// By("Print logs")
-	// myFile, err := os.ReadFile(randomReportDir + "/" + logfile)
-	// if err != nil {
-	// 	glog.Errorf("can not read file %s - %s", logfile, err)
-	// }
-	// fmt.Println(string(myFile))
+	logfile := "certsuite.log"
+	By("Print logs")
+	myFile, err := os.ReadFile(randomReportDir + "/" + logfile)
+	if err != nil {
+		glog.Errorf("can not read file %s - %s", logfile, err)
+	}
+	fmt.Println(string(myFile))
 	By(fmt.Sprintf("Remove reports from report directory: %s", randomReportDir))
 
-	err := RemoveContentsFromReportDir(randomReportDir)
+	err = RemoveContentsFromReportDir(randomReportDir)
 	Expect(err).ToNot(HaveOccurred())
 
 	By(fmt.Sprintf("Remove configs from config directory: %s", randomConfigDir))

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -98,16 +98,16 @@ func BeforeEachSetupWithRandomNamespace(incomingNamespace string) (randomNamespa
 }
 
 func AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, randomConfigDir string, waitingTime time.Duration) {
-	logfile := "certsuite.log"
-	By("Print logs")
-	myFile, err := os.ReadFile(randomReportDir + "/" + logfile)
-	if err != nil {
-		glog.Errorf("can not read file %s - %s", logfile, err)
-	}
-	fmt.Println(string(myFile))
+	// logfile := "certsuite.log"
+	// By("Print logs")
+	// myFile, err := os.ReadFile(randomReportDir + "/" + logfile)
+	// if err != nil {
+	// 	glog.Errorf("can not read file %s - %s", logfile, err)
+	// }
+	// fmt.Println(string(myFile))
 	By(fmt.Sprintf("Remove reports from report directory: %s", randomReportDir))
 
-	err = RemoveContentsFromReportDir(randomReportDir)
+	err := RemoveContentsFromReportDir(randomReportDir)
 	Expect(err).ToNot(HaveOccurred())
 
 	By(fmt.Sprintf("Remove configs from config directory: %s", randomConfigDir))

--- a/tests/globalhelper/operator.go
+++ b/tests/globalhelper/operator.go
@@ -184,6 +184,40 @@ func DeployRHCertifiedOperatorSource(ocpVersion string) error {
 	return nil
 }
 
+func DeleteCustomOperatorSource() error {
+	return DeleteCatalogSource("custom-catalog", "openshift-marketplace", "Custom Index")
+}
+
+func DeployCustomOperatorSource() error {
+	err := GetAPIClient().Create(context.TODO(),
+		&v1alpha1.CatalogSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "custom-catalog",
+				Namespace: "openshift-marketplace",
+			},
+			Spec: v1alpha1.CatalogSourceSpec{
+				SourceType:  "grpc",
+				Image:       "quay.io/deliedit/test:catalog-index-test",
+				DisplayName: "Custom Index",
+				Publisher:   "CertsuiteTeam",
+				UpdateStrategy: &v1alpha1.UpdateStrategy{
+					RegistryPoll: &v1alpha1.RegistryPoll{
+						Interval: &metav1.Duration{
+							Duration: 30 * time.Minute}},
+				},
+			},
+		},
+	)
+
+	if k8serrors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("can not deploy catalog source %w", err)
+	}
+
+	return nil
+}
+
 func DisableCatalogSource(name string) error {
 	return setCatalogSource(true, name)
 }

--- a/tests/operator/helper/helper.go
+++ b/tests/operator/helper/helper.go
@@ -106,10 +106,10 @@ func GetCsvByPrefix(prefixCsvName string, namespace string) (*v1alpha1.ClusterSe
 	return &neededCSV, nil
 }
 
-func DeployOperatorSubscription(operatorPackage, channel, namespace, group,
+func DeployOperatorSubscription(subscriptionName, operatorPackage, channel, namespace, group,
 	sourceNamespace, startingCSV string, installApproval v1alpha1.Approval) error {
 	operatorSubscription := utils.DefineSubscription(
-		operatorPackage+"-subscription",
+		subscriptionName+"-subscription",
 		namespace,
 		channel,
 		operatorPackage,

--- a/tests/operator/parameters/parameters.go
+++ b/tests/operator/parameters/parameters.go
@@ -63,4 +63,5 @@ const (
 	CertsuiteOperatorNonRoot                   = "operator-run-as-non-root"
 	CertsuiteOperatorPodAutomountToken         = "operator-automount-tokens"
 	CertsuiteOperatorPodRunAsUserID            = "operator-run-as-user-id"
+	CertsuiteOperatorMultipleInstalled         = "operator-multiple-same-operators"
 )

--- a/tests/operator/tests/operator_crd_openapi_schema.go
+++ b/tests/operator/tests/operator_crd_openapi_schema.go
@@ -38,6 +38,7 @@ var _ = Describe("Operator crd-openapi-schema", func() {
 		By("Deploy openvino operator for testing")
 		err = tshelper.DeployOperatorSubscription(
 			"ovms-operator",
+			"ovms-operator",
 			"alpha",
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,

--- a/tests/operator/tests/operator_crd_versioning.go
+++ b/tests/operator/tests/operator_crd_versioning.go
@@ -38,6 +38,7 @@ var _ = Describe("Operator crd-versioning,", func() {
 		By("Deploy openvino operator for testing")
 		err = tshelper.DeployOperatorSubscription(
 			"ovms-operator",
+			"ovms-operator",
 			"alpha",
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,

--- a/tests/operator/tests/operator_install_source.go
+++ b/tests/operator/tests/operator_install_source.go
@@ -73,18 +73,19 @@ var _ = Describe("Operator install-source,", Serial, func() {
 
 		By("Query the packagemanifest for defaultChannel for " + clusterLoggingOperatorName)
 		channel, err := globalhelper.QueryPackageManifestForDefaultChannel(clusterLoggingOperatorName, randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+clusterLoggingOperatorName)
 
 		fmt.Printf("CHANNEL FOUND: %s\n", channel)
 
 		By("Query the packagemanifest for the " + clusterLoggingOperatorName)
 		version, err := globalhelper.QueryPackageManifestForVersion(clusterLoggingOperatorName, randomNamespace, channel)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+clusterLoggingOperatorName)
 
 		fmt.Printf("VERSION FOUND: %s\n", version)
 
 		By("Deploy cluster-logging operator for testing")
 		err = tshelper.DeployOperatorSubscription(
+			clusterLoggingOperatorName,
 			clusterLoggingOperatorName,
 			channel,
 			openshiftLoggingNamespace,
@@ -139,6 +140,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 		// nginx-ingress-operator: in certified-operators group and version is certified
 		err = tshelper.DeployOperatorSubscription(
 			tsparams.CertifiedOperatorPrefixNginx,
+			tsparams.CertifiedOperatorPrefixNginx,
 			channel,
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,
@@ -182,6 +184,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 	It("one operator not installed with OLM [negative]", func() {
 		By("Deploy openvino operator for testing")
 		err := tshelper.DeployOperatorSubscription(
+			"ovms-operator",
 			"ovms-operator",
 			"alpha",
 			randomNamespace,
@@ -243,6 +246,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 		// nginx-ingress-operator: in certified-operators group and version is certified
 		err = tshelper.DeployOperatorSubscription(
 			tsparams.CertifiedOperatorPrefixNginx,
+			tsparams.CertifiedOperatorPrefixNginx,
 			channel,
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,
@@ -269,6 +273,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 
 		By("Deploy anchore-engine operator for testing")
 		err = tshelper.DeployOperatorSubscription(
+			tsparams.OperatorPrefixAnchore,
 			tsparams.OperatorPrefixAnchore,
 			"alpha",
 			randomNamespace,
@@ -317,6 +322,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 		By("Deploy openvino operator for testing")
 		err := tshelper.DeployOperatorSubscription(
 			"ovms-operator",
+			"ovms-operator",
 			"alpha",
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,
@@ -334,6 +340,7 @@ var _ = Describe("Operator install-source,", Serial, func() {
 
 		By("Deploy anchore-engine operator for testing")
 		err = tshelper.DeployOperatorSubscription(
+			tsparams.OperatorPrefixAnchore,
 			tsparams.OperatorPrefixAnchore,
 			"alpha",
 			randomNamespace,

--- a/tests/operator/tests/operator_install_status.go
+++ b/tests/operator/tests/operator_install_status.go
@@ -38,6 +38,7 @@ var _ = Describe("Operator install-source,", func() {
 		By("Deploy cloudbees-ci operator for testing")
 		err = tshelper.DeployOperatorSubscription(
 			"cloudbees-ci",
+			"cloudbees-ci",
 			"alpha",
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,
@@ -89,6 +90,7 @@ var _ = Describe("Operator install-source,", func() {
 		// The OpenVINO operator fails quickly due to the fact that it does not support the install mode type
 		// that it is used (OwnNamespace).
 		err := tshelper.DeployOperatorSubscription(
+			"ovms-operator",
 			"ovms-operator",
 			"alpha",
 			randomNamespace,

--- a/tests/operator/tests/operator_install_status_no_privileges.go
+++ b/tests/operator/tests/operator_install_status_no_privileges.go
@@ -39,6 +39,7 @@ var _ = Describe("Operator install-status-no-privileges,", func() {
 		By("Deploy cloudbees-ci operator for testing")
 		err = tshelper.DeployOperatorSubscription(
 			"cloudbees-ci",
+			"cloudbees-ci",
 			"alpha",
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,
@@ -58,6 +59,7 @@ var _ = Describe("Operator install-status-no-privileges,", func() {
 		By("Deploy quay operator for testing")
 		err = tshelper.DeployOperatorSubscription(
 			"project-quay",
+			"project-quay",
 			"stable-3.11",
 			randomNamespace,
 			tsparams.CommunityOperatorGroup,
@@ -76,6 +78,7 @@ var _ = Describe("Operator install-status-no-privileges,", func() {
 		// kiali operator has resourceNames under its rules
 		By("Deploy kiali operator for testing")
 		err = tshelper.DeployOperatorSubscription(
+			"kiali",
 			"kiali",
 			"alpha",
 			randomNamespace,

--- a/tests/operator/tests/operator_multiple_installed.go
+++ b/tests/operator/tests/operator_multiple_installed.go
@@ -1,0 +1,137 @@
+package operator
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
+	tshelper "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/operator/helper"
+	tsparams "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/operator/parameters"
+)
+
+var _ = Describe("Operator multiple installed,", func() {
+	var randomNamespace string
+	var secondNamespace string
+	var randomReportDir string
+	var randomCertsuiteConfigDir string
+
+	BeforeEach(func() {
+
+		// Create random namespace and keep original report and certsuite config directories
+		randomNamespace, randomReportDir, randomCertsuiteConfigDir =
+			globalhelper.BeforeEachSetupWithRandomNamespace(
+				tsparams.OperatorNamespace)
+
+		secondNamespace = randomNamespace + "-second"
+
+		By("Define certsuite config file")
+		err := globalhelper.DefineCertsuiteConfig(
+			[]string{randomNamespace, secondNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			tsparams.CertsuiteTargetCrdFilters, randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace,
+			randomReportDir, randomCertsuiteConfigDir, tsparams.Timeout)
+	})
+
+	It("Deploy the same operator (and version) twice in the different namespaces", func() {
+		// This is a positive test case to verify that the same operator can be deployed
+		// in different namespaces.  This is a valid use case.
+
+		By("Deploy operator group for namespace " + randomNamespace)
+		err := tshelper.DeployTestOperatorGroup(randomNamespace, false)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+
+		By("Create second namespace")
+		err = globalhelper.CreateNamespace(secondNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error creating namespace")
+
+		DeferCleanup(func() {
+			err := globalhelper.DeleteNamespaceAndWait(secondNamespace, tsparams.Timeout)
+			Expect(err).ToNot(HaveOccurred(), "Error deleting namespace")
+		})
+
+		By("Deploy operator group for namespace " + secondNamespace)
+		err = tshelper.DeployTestOperatorGroup(secondNamespace, false)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+
+		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx + " default channel")
+		channel, err := globalhelper.QueryPackageManifestForDefaultChannel(tsparams.CertifiedOperatorPrefixNginx, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		Expect(channel).ToNot(Equal("not found"), "Channel not found")
+
+		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx + " version")
+		version, err := globalhelper.QueryPackageManifestForVersion(tsparams.CertifiedOperatorPrefixNginx, randomNamespace, channel)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		Expect(version).ToNot(Equal("not found"), "Version not found")
+
+		// Note: The key to this setup is that the subscriptions can be named separately/uniquely.
+		// This is because the operator/csv name is the same, but the subscription name is different.
+		// The subscription name cannot be the same, as it is a unique identifier in the namespace.
+
+		By(fmt.Sprintf("Deploy first operator (nginx-ingress-operator) for testing"))
+		err = tshelper.DeployOperatorSubscription(
+			"operator1",
+			tsparams.CertifiedOperatorPrefixNginx,
+			channel,
+			randomNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.CertifiedOperatorPrefixNginx)
+
+		By("Deploy second operator (nginx-ingress-operator) for testing")
+		err = tshelper.DeployOperatorSubscription(
+			"operator2",
+			tsparams.CertifiedOperatorPrefixNginx,
+			channel,
+			secondNamespace,
+			tsparams.CertifiedOperatorGroup,
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.CertifiedOperatorPrefixNginx)
+
+		By("Wait until the first operator is ready")
+		err = tshelper.WaitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+
+			" is not ready")
+
+		By("Wait until the second operator is ready")
+		err = tshelper.WaitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx, secondNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+
+			" is not ready")
+
+		// Note: No need to label these operators as we are testing all operators in the cluster.
+		// At this point, two subscriptions, two installplans, and two CSVs should be present in the cluster.
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			tsparams.CertsuiteOperatorMultipleInstalled,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			randomReportDir,
+			randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Claim report")
+		err = globalhelper.ValidateIfReportsAreValid(
+			tsparams.CertsuiteOperatorMultipleInstalled,
+			globalparameters.TestCasePassed, randomReportDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+// TODO: Add a negative case here with two operators same name and different versions [negative]

--- a/tests/operator/tests/operator_multiple_installed.go
+++ b/tests/operator/tests/operator_multiple_installed.go
@@ -12,7 +12,7 @@ import (
 	tsparams "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/operator/parameters"
 )
 
-var _ = Describe("Operator multiple installed,", func() {
+var _ = Describe("Operator multiple installed,", Serial, func() {
 	var randomNamespace string
 	var secondNamespace string
 	var randomReportDir string
@@ -77,7 +77,7 @@ var _ = Describe("Operator multiple installed,", func() {
 		// This is because the operator/csv name is the same, but the subscription name is different.
 		// The subscription name cannot be the same, as it is a unique identifier in the namespace.
 
-		By(fmt.Sprintf("Deploy first operator (nginx-ingress-operator) for testing"))
+		By(fmt.Sprintf("Deploy first operator (nginx-ingress-operator) version %s for testing", version))
 		err = tshelper.DeployOperatorSubscription(
 			"operator1",
 			tsparams.CertifiedOperatorPrefixNginx,
@@ -91,7 +91,7 @@ var _ = Describe("Operator multiple installed,", func() {
 		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
 			tsparams.CertifiedOperatorPrefixNginx)
 
-		By("Deploy second operator (nginx-ingress-operator) for testing")
+		By(fmt.Sprintf("Deploy second operator (nginx-ingress-operator) version %s for testing", version))
 		err = tshelper.DeployOperatorSubscription(
 			"operator2",
 			tsparams.CertifiedOperatorPrefixNginx,
@@ -132,6 +132,94 @@ var _ = Describe("Operator multiple installed,", func() {
 			globalparameters.TestCasePassed, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
-})
 
-// TODO: Add a negative case here with two operators same name and different versions [negative]
+	It("Deploy the same operator (different versions) different namespaces [negative]", func() {
+		// This is a negative test case to verify that the same operator cannot be deployed
+		// in different namespaces with different versions.  This is an invalid use case.
+
+		// We want to create a custom catalog source for this test.
+		// This means we will have access to a "new" and "old" channel for the nginx-ingress-operator.
+		// We will deploy the "new" channel in the first namespace and the "old" channel in the second namespace.
+
+		By("Create custom-operator catalog source")
+		err := globalhelper.DeployCustomOperatorSource()
+		Expect(err).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			err := globalhelper.DeleteCustomOperatorSource()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("Deploy operator group for namespace " + randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+
+		By("Create second namespace")
+		err = globalhelper.CreateNamespace(secondNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error creating namespace")
+
+		DeferCleanup(func() {
+			err := globalhelper.DeleteNamespaceAndWait(secondNamespace, tsparams.Timeout)
+			Expect(err).ToNot(HaveOccurred(), "Error deleting namespace")
+		})
+
+		By("Deploy operator group for namespace " + secondNamespace)
+		err = tshelper.DeployTestOperatorGroup(secondNamespace, false)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+
+		By(fmt.Sprintf("Deploy first operator (nginx-ingress-operator) for testing - channel %s", "new"))
+		err = tshelper.DeployOperatorSubscription(
+			"operator1",
+			tsparams.CertifiedOperatorPrefixNginx,
+			"new",
+			randomNamespace,
+			"custom-catalog",
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorPrefixNginx+".v2.4.0",
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.CertifiedOperatorPrefixNginx)
+
+		By(fmt.Sprintf("Deploy second operator (nginx-ingress-operator) for testing - channel %s", "new"))
+		err = tshelper.DeployOperatorSubscription(
+			"operator2",
+			tsparams.CertifiedOperatorPrefixNginx,
+			"old",
+			secondNamespace,
+			"custom-catalog",
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorPrefixNginx+".v2.3.2",
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.CertifiedOperatorPrefixNginx)
+
+		By("Wait until the first operator is ready")
+		err = tshelper.WaitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+
+			" is not ready")
+
+		By("Wait until the second operator is ready")
+		err = tshelper.WaitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx, secondNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+
+			" is not ready")
+
+		// Note: No need to label these operators as we are testing all operators in the cluster.
+		// At this point, two subscriptions, two installplans, and two CSVs should be present in the cluster.
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			tsparams.CertsuiteOperatorMultipleInstalled,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			randomReportDir,
+			randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Claim report")
+		err = globalhelper.ValidateIfReportsAreValid(
+			tsparams.CertsuiteOperatorMultipleInstalled,
+			globalparameters.TestCaseFailed, randomReportDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/tests/operator/tests/operator_semantic_versioning.go
+++ b/tests/operator/tests/operator_semantic_versioning.go
@@ -39,6 +39,7 @@ var _ = Describe("Operator semantic-versioning,", func() {
 		By("Deploy openvino operator for testing")
 		err = tshelper.DeployOperatorSubscription(
 			"ovms-operator",
+			"ovms-operator",
 			"alpha",
 			randomNamespace,
 			tsparams.CertifiedOperatorGroup,


### PR DESCRIPTION
Adding tests for the new multiple-same-operators test case.

This PR includes a positive and negative test.

The positive test involves installing the same operator.version in two different namespaces.  This is a valid case.

The negative test involves installing different operator.version's in two different namespaces.  This is an invalid case.

