### PR TITLE
operator: add bundle-count test

### DIFF
--- a/tests/globalhelper/operator.go
+++ b/tests/globalhelper/operator.go
@@ -188,7 +188,7 @@ func DeleteCustomOperatorSource() error {
 	return DeleteCatalogSource("custom-catalog", "openshift-marketplace", "Custom Index")
 }
 
-func DeployCustomOperatorSource() error {
+func DeployCustomOperatorSource(image string) error {
 	err := GetAPIClient().Create(context.TODO(),
 		&v1alpha1.CatalogSource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -197,7 +197,7 @@ func DeployCustomOperatorSource() error {
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType:  "grpc",
-				Image:       "quay.io/deliedit/test:catalog-index-test",
+				Image:       image,
 				DisplayName: "Custom Index",
 				Publisher:   "CertsuiteTeam",
 				UpdateStrategy: &v1alpha1.UpdateStrategy{

--- a/tests/operator/parameters/parameters.go
+++ b/tests/operator/parameters/parameters.go
@@ -64,4 +64,5 @@ const (
 	CertsuiteOperatorPodAutomountToken         = "operator-automount-tokens"
 	CertsuiteOperatorPodRunAsUserID            = "operator-run-as-user-id"
 	CertsuiteOperatorMultipleInstalled         = "operator-multiple-same-operators"
+	CertsuiteOperatorBundleCount               = "operator-catalogsource-bundle-count"
 )

--- a/tests/operator/tests/operator_bundle_image.go
+++ b/tests/operator/tests/operator_bundle_image.go
@@ -1,0 +1,98 @@
+package operator
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
+	tshelper "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/operator/helper"
+	tsparams "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/operator/parameters"
+)
+
+var _ = Describe("Operator bundle count,", Serial, func() {
+	var randomNamespace string
+	var randomReportDir string
+	var randomCertsuiteConfigDir string
+
+	BeforeEach(func() {
+
+		// Create random namespace and keep original report and certsuite config directories
+		randomNamespace, randomReportDir, randomCertsuiteConfigDir =
+			globalhelper.BeforeEachSetupWithRandomNamespace(
+				tsparams.OperatorNamespace)
+
+		By("Define certsuite config file")
+		err := globalhelper.DefineCertsuiteConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			tsparams.CertsuiteTargetCrdFilters, randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace,
+			randomReportDir, randomCertsuiteConfigDir, tsparams.Timeout)
+	})
+
+	It("CatalogSource with less than 1000 bundle images", func() {
+		By("Create custom-operator catalog source")
+		err := globalhelper.DeployCustomOperatorSource("quay.io/deliedit/test:catalog-index-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			err := globalhelper.DeleteCustomOperatorSource()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("Deploy operator group for namespace " + randomNamespace)
+		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
+		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
+
+		By(fmt.Sprintf("Deploy first operator (nginx-ingress-operator) for testing - channel %s", "new"))
+		err = tshelper.DeployOperatorSubscription(
+			"operator1",
+			tsparams.CertifiedOperatorPrefixNginx,
+			"new",
+			randomNamespace,
+			"custom-catalog",
+			tsparams.OperatorSourceNamespace,
+			tsparams.CertifiedOperatorPrefixNginx+".v2.4.0",
+			v1alpha1.ApprovalAutomatic,
+		)
+		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
+			tsparams.CertifiedOperatorPrefixNginx)
+
+		By("Wait until operator is ready")
+		err = tshelper.WaitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+
+			" is not ready")
+
+		By("Label operator")
+		Eventually(func() error {
+			return tshelper.AddLabelToInstalledCSV(
+				tsparams.CertifiedOperatorPrefixNginx,
+				randomNamespace,
+				tsparams.OperatorLabel)
+		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
+			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			tsparams.CertsuiteOperatorBundleCount,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()),
+			randomReportDir,
+			randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Claim report")
+		err = globalhelper.ValidateIfReportsAreValid(
+			tsparams.CertsuiteOperatorBundleCount,
+			globalparameters.TestCasePassed, randomReportDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/tests/operator/tests/operator_multiple_installed.go
+++ b/tests/operator/tests/operator_multiple_installed.go
@@ -142,7 +142,7 @@ var _ = Describe("Operator multiple installed,", Serial, func() {
 		// We will deploy the "new" channel in the first namespace and the "old" channel in the second namespace.
 
 		By("Create custom-operator catalog source")
-		err := globalhelper.DeployCustomOperatorSource()
+		err := globalhelper.DeployCustomOperatorSource("quay.io/deliedit/test:catalog-index-test")
 		Expect(err).ToNot(HaveOccurred())
 
 		DeferCleanup(func() {


### PR DESCRIPTION
Adds a positive and negative test for the new `operator-bundle-count` test.

Marked WIP until https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2549 merges.