### PR TITLE
acccess_control_sys_admin_capability ts: add two positive tcs.

### DIFF
--- a/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_sys_admin_capability_check.go
@@ -81,7 +81,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		runningPods, err := globalhelper.GetListOfPodsInNamespace(randomNamespace)
 		Expect(err).ToNot(HaveOccurred(), "Failed getting list of pods in namespace "+randomNamespace)
 
-		Expect(len(runningPods.Items)).To(Equal(1), "Invalid number of pods in namspace "+randomNamespace)
+		Expect(len(runningPods.Items)).To(Equal(1), "Invalid number of pods in namespace "+randomNamespace)
 
 		pod := &runningPods.Items[0]
 		By("Ensure pod " + pod.Name + " has dropped SYS_ADMIN cap")
@@ -197,7 +197,7 @@ var _ = Describe("Access-control sys-admin-capability-check,", func() {
 		runningPods, err := globalhelper.GetListOfPodsInNamespace(randomNamespace)
 		Expect(err).ToNot(HaveOccurred(), "Failed getting list of pods in namespace "+randomNamespace)
 
-		Expect(len(runningPods.Items)).To(Equal(2), "Invalid number of pods in namspace "+randomNamespace)
+		Expect(len(runningPods.Items)).To(Equal(2), "Invalid number of pods in namespace "+randomNamespace)
 
 		for i := range runningPods.Items {
 			pod := runningPods.Items[i]

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -475,6 +475,29 @@ func RedefineWithContainersSecurityContextSysAdmin(deployment *appsv1.Deployment
 	}
 }
 
+func RedefineWithContainersSecurityContextCaps(deployment *appsv1.Deployment, add, drop []string) {
+	var addedCaps, droppedCaps []corev1.Capability
+
+	for _, cap := range add {
+		addedCaps = append(addedCaps, corev1.Capability(cap))
+	}
+
+	for _, cap := range drop {
+		droppedCaps = append(droppedCaps, corev1.Capability(cap))
+	}
+
+	for index := range deployment.Spec.Template.Spec.Containers {
+		deployment.Spec.Template.Spec.Containers[index].SecurityContext = &corev1.SecurityContext{
+			Privileged: ptr.To[bool](true),
+			RunAsUser:  ptr.To[int64](0),
+			Capabilities: &corev1.Capabilities{
+				Add:  addedCaps,
+				Drop: droppedCaps,
+			},
+		}
+	}
+}
+
 func RedefineWithContainersSecurityContextBpf(deployment *appsv1.Deployment) {
 	for index := range deployment.Spec.Template.Spec.Containers {
 		deployment.Spec.Template.Spec.Containers[index].SecurityContext = &corev1.SecurityContext{


### PR DESCRIPTION
These two test cases cover this certsuite fix PR:
https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2352

Without that certsuite fix, the tc `access-control-sys-admin-capability-check` failed also when the forbidden capability SYS_ADMIN was set in the drop list, which is wrong.

These new QE tcs make sure the certsuite tc passes in that scenario.