### PR TITLE
Add log output for debugging when helm installation fails.

### DIFF
--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -44,8 +44,8 @@ var _ = SynchronizedBeforeSuite(func() {
 			"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"+
 				" && chmod +x get_helm.sh"+
 				" && ./get_helm.sh")
-		err := cmd.Run()
-		Expect(err).ToNot(HaveOccurred(), "Error installing helm v3")
+		out, err := cmd.CombinedOutput()
+		Expect(err).ToNot(HaveOccurred(), "Error installing helm v3: "+string(out))
 	}
 
 	By("Preemptively delete tiller-deploy pod if its installed")


### PR DESCRIPTION
Just added the stdout+stderr output of the helm tool installation as the affiliated test suite seems to fail too often. As this happens at the SynchronizedBeforeSuite() func, all the test cases are skipped when it happens.

I've seen this failure in all our OCP versions where we run QE.

Last failing runs in 4.16:
- https://github.com/redhat-best-practices-for-k8s/certsuite/actions/runs/12919752505
- https://github.com/redhat-best-practices-for-k8s/certsuite/actions/runs/13001158158
- https://github.com/redhat-best-practices-for-k8s/certsuite/actions/runs/13220699737