### PR TITLE
Add logic for namespace cleanup and Serial

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,7 +69,7 @@ linters:
     - rowserrcheck
     - staticcheck
     - stylecheck
-    - tenv
+    - usetesting
     - thelper
     - tparallel
     - typecheck

--- a/tests/accesscontrol/helper/helper_test.go
+++ b/tests/accesscontrol/helper/helper_test.go
@@ -1,7 +1,6 @@
 package helper
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -124,7 +123,7 @@ func TestSetServiceAccountAutomountServiceAccountToken(t *testing.T) {
 
 		// Get the serviceaccount from the fake client and check if the automountServiceAccountToken is set to the test value
 		serviceAccount, err := client.CoreV1().
-			ServiceAccounts(parameters.TestAccessControlNameSpace).Get(context.TODO(), "my-service-account", metav1.GetOptions{})
+			ServiceAccounts(parameters.TestAccessControlNameSpace).Get(t.Context(), "my-service-account", metav1.GetOptions{})
 		assert.Nil(t, err)
 
 		if err == nil {
@@ -188,7 +187,7 @@ func TestDefineAndCreateServiceOnCluster(t *testing.T) {
 		assert.Nil(t, err)
 
 		// Get the service from the fake client and check if it exists
-		_, err = client.CoreV1().Services(parameters.TestAccessControlNameSpace).Get(context.TODO(), "service-name", metav1.GetOptions{})
+		_, err = client.CoreV1().Services(parameters.TestAccessControlNameSpace).Get(t.Context(), "service-name", metav1.GetOptions{})
 		assert.Nil(t, err)
 
 		globalhelper.UnsetTestK8sAPIClient()

--- a/tests/globalhelper/clusterroles_test.go
+++ b/tests/globalhelper/clusterroles_test.go
@@ -1,7 +1,6 @@
 package globalhelper
 
 import (
-	"context"
 	"testing"
 
 	egiClients "github.com/openshift-kni/eco-goinfra/pkg/clients"
@@ -42,7 +41,7 @@ func TestDeleteClusterRole(t *testing.T) {
 		})
 		assert.Nil(t, deleteClusterRole(fakeClient, testCR.Name))
 
-		_, err := fakeClient.RbacV1Interface.ClusterRoles().Get(context.TODO(), testCR.Name, metav1.GetOptions{})
+		_, err := fakeClient.RbacV1Interface.ClusterRoles().Get(t.Context(), testCR.Name, metav1.GetOptions{})
 		assert.NotNil(t, err)
 		assert.True(t, k8serrors.IsNotFound(err))
 	}

--- a/tests/globalhelper/namespaces_test.go
+++ b/tests/globalhelper/namespaces_test.go
@@ -1,7 +1,6 @@
 package globalhelper
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -151,7 +150,7 @@ func TestCleanPVCs(t *testing.T) {
 
 		if testCase.namespaceExists {
 			// check if namespace has no pvcs left
-			pvcs, err := fakeClient.K8sClient.CoreV1().PersistentVolumeClaims(testCase.namespace).List(context.TODO(), metav1.ListOptions{})
+			pvcs, err := fakeClient.K8sClient.CoreV1().PersistentVolumeClaims(testCase.namespace).List(t.Context(), metav1.ListOptions{})
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(pvcs.Items))
 		}
@@ -201,7 +200,7 @@ func TestCleanPodDisruptionBudget(t *testing.T) {
 		if testCase.namespaceExists {
 			// check if namespace has no pod disruption budgets left
 			pdbs, err := fakeClient.K8sClient.PolicyV1beta1().
-				PodDisruptionBudgets(testCase.namespace).List(context.TODO(), metav1.ListOptions{})
+				PodDisruptionBudgets(testCase.namespace).List(t.Context(), metav1.ListOptions{})
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(pdbs.Items))
 		}

--- a/tests/globalhelper/nodes_test.go
+++ b/tests/globalhelper/nodes_test.go
@@ -1,7 +1,6 @@
 package globalhelper
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +40,7 @@ func TestAddControlPlaneTaint(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Check that the taint was added
-	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodes, err := client.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
 	assert.Nil(t, err)
 
 	for _, node := range nodes.Items {
@@ -78,7 +77,7 @@ func TestRemoveControlPlaneTaint(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Check that the taint was added
-	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodes, err := client.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
 	assert.Nil(t, err)
 
 	for _, node := range nodes.Items {

--- a/tests/operator/tests/operator_single_or_multi_namespaced_allowed_in_tenant_namespaces.go
+++ b/tests/operator/tests/operator_single_or_multi_namespaced_allowed_in_tenant_namespaces.go
@@ -14,7 +14,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/utils/pod"
 )
 
-var _ = Describe("Operator single-or-multi-namespaced-allowed-in-tenant-namespaces", func() {
+var _ = Describe("Operator single-or-multi-namespaced-allowed-in-tenant-namespaces", Serial, func() {
 	var randomNamespace string
 	var randomReportDir string
 	var randomCertsuiteConfigDir string
@@ -277,9 +277,18 @@ func installClusterWideOperator() {
 		openshiftLoggingNamespace  = "cluster-logging"
 	)
 
+	By("Preemptively delete the namespace if it already exists")
+	err := globalhelper.DeleteNamespaceAndWait(openshiftLoggingNamespace, tsparams.Timeout)
+	Expect(err).ToNot(HaveOccurred(), "Error deleting namespace "+openshiftLoggingNamespace)
+
 	By("Create openshift-logging namespace")
-	err := globalhelper.CreateNamespace(openshiftLoggingNamespace)
+	err = globalhelper.CreateNamespace(openshiftLoggingNamespace)
 	Expect(err).ToNot(HaveOccurred())
+
+	DeferCleanup(func() {
+		err := globalhelper.DeleteNamespaceAndWait(openshiftLoggingNamespace, tsparams.Timeout)
+		Expect(err).ToNot(HaveOccurred(), "Error deleting namespace "+openshiftLoggingNamespace)
+	})
 
 	By("Create fake operator group for cluster-logging operator")
 	err = tshelper.DeployTestOperatorGroup(openshiftLoggingNamespace, true)

--- a/tests/utils/nodes/nodes_test.go
+++ b/tests/utils/nodes/nodes_test.go
@@ -1,7 +1,6 @@
 package nodes
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -47,7 +46,7 @@ func TestEnsureAllNodesAreLabeled(t *testing.T) {
 		client := k8sfake.NewSimpleClientset(runtimeObjects...)
 
 		// Get all of the nodes from the fake client and test their labels
-		nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		nodes, err := client.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(nodes.Items))
 
@@ -99,7 +98,7 @@ func TestAddControlPlaneTaint(t *testing.T) {
 		assert.Nil(t, addControlPlaneTaint(client.CoreV1().Nodes(), testNode))
 
 		// Get all of the nodes from the fake client and test their labels
-		nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		nodes, err := client.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(nodes.Items))
 
@@ -138,7 +137,7 @@ func TestRemoveControlPlaneTaint(t *testing.T) {
 		assert.Nil(t, removeControlPlaneTaint(client.CoreV1().Nodes(), testNode))
 
 		// Get all of the nodes from the fake client and test their labels
-		nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		nodes, err := client.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(nodes.Items))
 
@@ -279,7 +278,7 @@ func TestUnCordon(t *testing.T) {
 	assert.Nil(t, UnCordon(client.CoreV1().Nodes(), testNode.Name))
 
 	// Get all of the nodes from the fake client and test their labels
-	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodes, err := client.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(nodes.Items))
 
@@ -300,7 +299,7 @@ func TestEnableMasterScheduling(t *testing.T) {
 	assert.Nil(t, EnableMasterScheduling(client.CoreV1().Nodes(), true))
 
 	// Get all of the nodes from the fake client and test their labels
-	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodes, err := client.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(nodes.Items))
 
@@ -309,7 +308,7 @@ func TestEnableMasterScheduling(t *testing.T) {
 
 	// Disable master scheduling
 	assert.Nil(t, EnableMasterScheduling(client.CoreV1().Nodes(), false))
-	nodes, err = client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodes, err = client.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(nodes.Items))
 	assert.NotZero(t, nodes.Items[0].Spec.Taints)


### PR DESCRIPTION
Follow up to #1084 

Run the `single-or-multi-namespaced-allowed-in-tenant-namespaces` test in Serial and also add some cleanup for the namespace prior to running.  There was a leftover `cluster-logging` namespace that was leftover during a failed run so it was throwing the tests off.