### PR TITLE
platform-alteration: Add positive test for OCP-only clusters

### DIFF
--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -105,8 +105,7 @@ func AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, rando
 	// 	glog.Errorf("can not read file %s - %s", logfile, err)
 	// }
 	// fmt.Println(string(myFile))
-	By(fmt.Sprintf("Remove reports from report directory: %s", randomReportDir))
-
+	// By(fmt.Sprintf("Remove reports from report directory: %s", randomReportDir))
 	err := RemoveContentsFromReportDir(randomReportDir)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/tests/platformalteration/parameters/parameters.go
+++ b/tests/platformalteration/parameters/parameters.go
@@ -43,6 +43,7 @@ const (
 	CertsuiteOCPLifecycleName       = "platform-alteration-ocp-lifecycle"
 	CertsuiteOCPNodeOsName          = "platform-alteration-ocp-node-os-lifecycle"
 	CertsuiteServiceMeshUsageName   = "platform-alteration-service-mesh-usage"
+	CertsuiteClusterOperatorHealth  = "platform-alteration-cluster-operator-health"
 
 	Getenforce    = `chroot /host getenforce`
 	Enforcing     = "Enforcing"

--- a/tests/platformalteration/tests/platform_alteration_cluster_operator_health.go
+++ b/tests/platformalteration/tests/platform_alteration_cluster_operator_health.go
@@ -1,0 +1,58 @@
+package tests
+
+import (
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
+	tsparams "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/platformalteration/parameters"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("platform-alteration-cluster-operator-health", func() {
+	var randomNamespace string
+	var randomReportDir string
+	var randomCertsuiteConfigDir string
+
+	BeforeEach(func() {
+		// Create random namespace and keep original report and certsuite config directories
+		randomNamespace, randomReportDir, randomCertsuiteConfigDir =
+			globalhelper.BeforeEachSetupWithRandomNamespace(
+				tsparams.PlatformAlterationNamespace)
+
+		By("Define certsuite config file")
+		err := globalhelper.DefineCertsuiteConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{}, randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("If Kind cluster, skip")
+		if globalhelper.IsKindCluster() {
+			Skip("Kind cluster does not have cluster operators")
+		}
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace,
+			randomReportDir, randomCertsuiteConfigDir, tsparams.WaitingTime)
+	})
+
+	It("cluster operator health", func() {
+		// This is a simple test that is just checking the overall health of the cluster operators
+		// in an OpenShift cluster. It is not testing any specific functionality of the cluster operators.
+		// It is just checking that they are running and healthy.
+		// This test is not applicable to a Kind cluster, so it is skipped in that case.
+		By("Start platform-alteration-cluster-operator-health test")
+		err := globalhelper.LaunchTests(tsparams.CertsuiteClusterOperatorHealth,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalhelper.ValidateIfReportsAreValid(
+			tsparams.CertsuiteClusterOperatorHealth,
+			globalparameters.TestCasePassed, randomReportDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/tests/platformalteration/tests/platform_alteration_cluster_operator_health_test.go
+++ b/tests/platformalteration/tests/platform_alteration_cluster_operator_health_test.go
@@ -1,0 +1,1 @@
+package tests


### PR DESCRIPTION
Adds tests for: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2787

![image](https://github.com/user-attachments/assets/48170db8-edf4-4944-a736-cbb0aaa7f5db)
