### PR TITLE
Speed up IsReady funcs; add OCP nightly

### DIFF
--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -1,0 +1,74 @@
+---
+name: QE OCP Testing (Ubuntu-hosted)
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+  # Schedule a daily cron at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  qe-ocp-testing:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+    env:
+      SHELL: /bin/bash
+      KUBECONFIG: '/home/runner/.kube/config'
+      PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
+      TEST_CERTSUITE_IMAGE_NAME: quay.io/redhat-best-practices-for-k8s/certsuite
+      TEST_CERTSUITE_IMAGE_TAG: unstable
+      DOCKER_CONFIG_DIR: '/home/runner/.docker/'
+      SKIP_PRELOAD_IMAGES: true # Not needed for github-hosted runs
+      TEST_REPO: redhat-best-practices-for-k8s/certsuite
+
+    steps:
+      - name: Write temporary docker file
+        run: |
+          mkdir -p /home/runner/.docker
+          touch ${PFLT_DOCKERCONFIG}
+          echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
+
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Disable default go problem matcher
+        run: echo "::remove-matcher owner=go::"
+
+      - name: Setup up OCP cluster
+        uses: palmsoftware/quick-ocp@v0.0.16
+        with:
+          ocpPullSecret: $OCP_PULL_SECRET
+          bundleCache: true
+          waitForOperatorsReady: true
+        env:
+          OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
+
+      - name: Show pods
+        run: oc get pods -A
+
+      - name: Clone the certsuite repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ env.TEST_REPO }}
+          path: certsuite
+          ref: main
+
+      - name: Run the tests (against image)
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 150
+          max_attempts: 3
+          command: FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE}/certsuite CERTSUITE_IMAGE=${{env.TEST_CERTSUITE_IMAGE_NAME}} CERTSUITE_IMAGE_TAG=${{env.TEST_CERTSUITE_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true JOB_ID=${{github.run_id}} make test-features
+

--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -1,10 +1,9 @@
 ---
-
 name: QE Testing (Ubuntu-hosted)
 
 on:
-  pull_request:
-    branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
   workflow_dispatch:
   # Schedule a daily cron at midnight UTC
   schedule:
@@ -97,7 +96,7 @@ jobs:
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          timeout_minutes: 60
+          timeout_minutes: 150
           max_attempts: 3
           command: FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE}/certsuite CERTSUITE_IMAGE=${{env.TEST_CERTSUITE_IMAGE_NAME}} CERTSUITE_IMAGE_TAG=${{env.TEST_CERTSUITE_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true JOB_ID=${{github.run_id}} make test-features
 
@@ -109,7 +108,7 @@ jobs:
       - name: Run the tests (against binary)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          timeout_minutes: 60
+          timeout_minutes: 150
           max_attempts: 3
           command: FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE}/certsuite USE_BINARY=true DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true JOB_ID=${{github.run_id}} make test-features
 

--- a/tests/globalhelper/daemonset.go
+++ b/tests/globalhelper/daemonset.go
@@ -37,13 +37,13 @@ func createAndWaitUntilDaemonSetIsReady(client *egiClients.Settings,
 		status, err := isDaemonSetReady(client, runningDaemonSet.Namespace, runningDaemonSet.Name)
 		if err != nil {
 			glog.Errorf(
-				"daemonset %s is not ready, retry in 5 seconds", runningDaemonSet.Name)
+				"daemonset %s is not ready, retry in 1 second", runningDaemonSet.Name)
 
 			return false
 		}
 
 		return status
-	}, timeout, retryInterval*time.Second).Should(Equal(true), "DaemonSet is not ready")
+	}, timeout, 1*time.Second).Should(Equal(true), "DaemonSet is not ready")
 
 	return nil
 }

--- a/tests/globalhelper/deployment.go
+++ b/tests/globalhelper/deployment.go
@@ -23,7 +23,7 @@ func IsDeploymentReady(client *egiClients.Settings, namespace, deploymentName st
 		return false, fmt.Errorf("failed to get deployment %q (ns %s): %w", deploymentName, namespace, err)
 	}
 
-	return dep.IsReady(5 * time.Second), nil
+	return dep.IsReady(1 * time.Second), nil
 }
 
 // CreateAndWaitUntilDeploymentIsReady creates deployment and wait until all deployment replicas are up and running.
@@ -57,7 +57,7 @@ func createAndWaitUntilDeploymentIsReady(client *egiClients.Settings, deployment
 
 		if err != nil {
 			glog.V(5).Info(fmt.Sprintf(
-				"deployment %s is not running, retry in 5 seconds", testDeployment.Name))
+				"deployment %s is not running, retry in 1 second", testDeployment.Name))
 
 			return false
 		}
@@ -82,7 +82,7 @@ func createAndWaitUntilDeploymentIsReady(client *egiClients.Settings, deployment
 		}
 
 		return deploymentUnschedulable
-	}, timeout, 5*time.Second).Should(Equal(true), "Deployment is not running")
+	}, timeout, 1*time.Second).Should(Equal(true), "Deployment is not running")
 
 	if deploymentUnschedulable {
 		return fmt.Errorf("deployment %s is not schedulable", runningDeployment.Name)
@@ -92,13 +92,13 @@ func createAndWaitUntilDeploymentIsReady(client *egiClients.Settings, deployment
 		status, err := IsDeploymentReady(client, runningDeployment.Namespace, runningDeployment.Name)
 		if err != nil {
 			glog.V(5).Info(fmt.Sprintf(
-				"deployment %s is not ready, retry in 5 seconds", runningDeployment.Name))
+				"deployment %s is not ready, retry in 1 second", runningDeployment.Name))
 
 			return false
 		}
 
 		return status
-	}, timeout, retryInterval*time.Second).Should(Equal(true), "Deployment is not ready")
+	}, timeout, 1*time.Second).Should(Equal(true), "Deployment is not ready")
 
 	return nil
 }

--- a/tests/globalhelper/pod.go
+++ b/tests/globalhelper/pod.go
@@ -86,7 +86,7 @@ func CreateAndWaitUntilPodIsReady(pod *corev1.Pod, timeout time.Duration) error 
 
 		if err != nil {
 			glog.V(5).Info(fmt.Sprintf(
-				"Pod %s is not running, retry in %d seconds", createdPod.Name, retryInterval))
+				"Pod %s is not running, retry in 1 second", createdPod.Name))
 
 			return false
 		}
@@ -108,7 +108,7 @@ func CreateAndWaitUntilPodIsReady(pod *corev1.Pod, timeout time.Duration) error 
 		}
 
 		return podUnschedulable
-	}, timeout, retryInterval*time.Second).Should(Equal(true), "Pod is not running")
+	}, timeout, 1*time.Second).Should(Equal(true), "Pod is not running")
 
 	if podUnschedulable {
 		return fmt.Errorf("pod %s is not schedulable", createdPod.Name)
@@ -119,13 +119,13 @@ func CreateAndWaitUntilPodIsReady(pod *corev1.Pod, timeout time.Duration) error 
 		if err != nil {
 
 			glog.V(5).Info(fmt.Sprintf(
-				"Pod %s is not ready, retry in %d seconds", createdPod.Name, retryInterval))
+				"Pod %s is not ready, retry in 1 second", createdPod.Name))
 
 			return false
 		}
 
 		return status
-	}, timeout, retryInterval*time.Second).Should(Equal(true), "Pod is not ready")
+	}, timeout, 1*time.Second).Should(Equal(true), "Pod is not ready")
 
 	return nil
 }

--- a/tests/globalhelper/replicaset.go
+++ b/tests/globalhelper/replicaset.go
@@ -26,13 +26,13 @@ func CreateAndWaitUntilReplicaSetIsReady(replicaSet *appsv1.ReplicaSet, timeout 
 		status, err := isReplicaSetReady(runningReplica.Namespace, runningReplica.Name)
 		if err != nil {
 			glog.V(5).Info(fmt.Sprintf(
-				"replicaSet %s is not ready, retry in %d seconds", runningReplica.Name, retryInterval))
+				"replicaSet %s is not ready, retry in 1 second", runningReplica.Name))
 
 			return false
 		}
 
 		return status
-	}, timeout, retryInterval*time.Second).Should(Equal(true), "replicaSet is not ready")
+	}, timeout, 1*time.Second).Should(Equal(true), "replicaSet is not ready")
 
 	return nil
 }

--- a/tests/globalhelper/statefulset.go
+++ b/tests/globalhelper/statefulset.go
@@ -36,13 +36,13 @@ func createAndWaitUntilStatefulSetIsReady(client *egiClients.Settings, statefulS
 		status, err := isStatefulSetReady(client, statefulSet.Namespace, statefulSet.Name)
 		if err != nil {
 			glog.V(5).Info(fmt.Sprintf(
-				"statefulSet %s is not ready, retry in %d seconds", statefulSet.Name, retryInterval))
+				"statefulSet %s is not ready, retry in 1 second", statefulSet.Name))
 
 			return false
 		}
 
 		return status
-	}, timeout, retryInterval*time.Second).Should(Equal(true), "statefulSet is not ready")
+	}, timeout, 1*time.Second).Should(Equal(true), "statefulSet is not ready")
 
 	return nil
 }
@@ -54,7 +54,7 @@ func isStatefulSetReady(client *egiClients.Settings, namespace, statefulSetName 
 		return false, fmt.Errorf("failed to get statefulSet %q (ns %s): %w", statefulSetName, namespace, err)
 	}
 
-	return testStatefulSet.IsReady(5 * time.Second), nil
+	return testStatefulSet.IsReady(1 * time.Second), nil
 }
 
 func GetRunningStatefulSet(namespace, statefulSetName string) (*appsv1.StatefulSet, error) {


### PR DESCRIPTION
Adds some modifications to the IsReady funcs to speed up the detection of ready objects.  Adds an OCP nightly run using quick-ocp.

### Workflow Updates:
* [`.github/workflows/qe-ocp.yml`](diffhunk://#diff-c13b14c9b655fb5672a795fc5e1c27be6d66587dfa15f814f0ccf78e4a50277fR1-R93): Added a new workflow for QE OCP Testing on Ubuntu-hosted runners. This includes matrix testing for multiple suites, environment variable setup, dependency installation, OCP cluster setup, and test execution against both images and binaries.
* [`.github/workflows/qe.yml`](diffhunk://#diff-a90bd711e6964ed07f1bd5524ede4bbbdc4a51f8baab54f295f8ec3fbccb8cbdL2): Removed an unnecessary blank line to clean up the file.

### Retry Interval Optimization:
* [`tests/globalhelper/daemonset.go`](diffhunk://#diff-11cb7135b810afc282ac7d99c79a622b1d02db3cc98a06c0d9b5c3048a484854L40-R46): Reduced retry intervals from 5 seconds to 1 second in `createAndWaitUntilDaemonSetIsReady`.
* [`tests/globalhelper/deployment.go`](diffhunk://#diff-4dd2700af63536edc606345a2beedade8bd21993487b229c398d67557fd647d6L26-R26): Reduced retry intervals from 5 seconds to 1 second in readiness checks for deployments (`IsDeploymentReady` and `createAndWaitUntilDeploymentIsReady`). [[1]](diffhunk://#diff-4dd2700af63536edc606345a2beedade8bd21993487b229c398d67557fd647d6L26-R26) [[2]](diffhunk://#diff-4dd2700af63536edc606345a2beedade8bd21993487b229c398d67557fd647d6L60-R60) [[3]](diffhunk://#diff-4dd2700af63536edc606345a2beedade8bd21993487b229c398d67557fd647d6L85-R85) [[4]](diffhunk://#diff-4dd2700af63536edc606345a2beedade8bd21993487b229c398d67557fd647d6L95-R101)
* [`tests/globalhelper/pod.go`](diffhunk://#diff-e2054d247376a4253808e5aea3afcbee80d79513f23e6b0a60644b04cc9b404bL89-R89): Reduced retry intervals from 5 seconds to 1 second in `CreateAndWaitUntilPodIsReady`. [[1]](diffhunk://#diff-e2054d247376a4253808e5aea3afcbee80d79513f23e6b0a60644b04cc9b404bL89-R89) [[2]](diffhunk://#diff-e2054d247376a4253808e5aea3afcbee80d79513f23e6b0a60644b04cc9b404bL111-R111) [[3]](diffhunk://#diff-e2054d247376a4253808e5aea3afcbee80d79513f23e6b0a60644b04cc9b404bL122-R128)
* [`tests/globalhelper/replicaset.go`](diffhunk://#diff-dae0229587c3cddbe957d4e1afa70e4f81179cfc463984e49f2d4953b52c5fc2L29-R35): Reduced retry intervals from 5 seconds to 1 second in `CreateAndWaitUntilReplicaSetIsReady`.
* [`tests/globalhelper/statefulset.go`](diffhunk://#diff-3a6542db4c5f7d8a479a396ba61ede4107cbda1a6c4b830ab3bb275595647afaL39-R45): Reduced retry intervals from 5 seconds to 1 second in readiness checks for statefulsets (`createAndWaitUntilStatefulSetIsReady` and `isStatefulSetReady`). [[1]](diffhunk://#diff-3a6542db4c5f7d8a479a396ba61ede4107cbda1a6c4b830ab3bb275595647afaL39-R45) [[2]](diffhunk://#diff-3a6542db4c5f7d8a479a396ba61ede4107cbda1a6c4b830ab3bb275595647afaL57-R57)