### PR TITLE
Skip these intrusive tests on CRC environments

### DIFF
--- a/tests/lifecycle/tests/lifecycle_deployment_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_deployment_scaling.go
@@ -53,6 +53,9 @@ var _ = Describe("lifecycle-deployment-scaling", Serial, func() {
 
 	// 47398
 	It("One deployment, one pod, one container, scale in and out", func() {
+		if globalhelper.IsCRCCluster() {
+			Skip("Deployment scaling test is not supported on CRC clusters")
+		}
 
 		By("Define Deployment")
 		deploymenta, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -61,6 +61,10 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 	// 47405
 	It("One deployment with PodAntiAffinity, replicas are less than schedulable nodes", func() {
+		if globalhelper.IsCRCCluster() {
+			Skip("PodAntiAffinity test is not supported on CRC clusters")
+		}
+
 		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
@@ -148,6 +152,10 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 	// 47407
 	It("One deployment with PodAntiAffinity, replicas are equal to schedulable nodes [negative]", func() {
+		if globalhelper.IsCRCCluster() {
+			Skip("PodAntiAffinity test is not supported on CRC clusters")
+		}
+
 		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
@@ -60,6 +60,10 @@ var _ = Describe("lifecycle-statefulset-scaling", Serial, func() {
 
 	// 45439
 	It("One statefulSet, one pod", func() {
+		if globalhelper.IsCRCCluster() {
+			Skip("StatefulSet scaling test is not supported on CRC clusters")
+		}
+
 		By("Define statefulSet")
 		statefulset := tshelper.DefineStatefulSet(tsparams.TestStatefulSetName, randomNamespace)
 


### PR DESCRIPTION
This pull request introduces a new helper function to detect CRC (Code Ready Containers) clusters and updates several lifecycle tests to skip execution on CRC clusters. These changes ensure compatibility and prevent unsupported tests from running in CRC environments.

### Detection of CRC clusters:

* Added `func IsCRCCluster()` in `tests/globalhelper/helper.go` to identify CRC clusters using domain patterns, node characteristics, and labels.

### Updates to lifecycle tests:

* [`tests/lifecycle/tests/lifecycle_deployment_scaling.go`](diffhunk://#diff-130e6ce5d8e09b25db8a15193eab1e4909d123386c65f35ffcd78e5b8c7f5571R56-R58): Modified the deployment scaling test to skip execution on CRC clusters using `globalhelper.IsCRCCluster()`.
* [`tests/lifecycle/tests/lifecycle_pod_recreation.go`](diffhunk://#diff-f513dd31a32dd37da5db58189089864dbe14ad5360a891d8e31e077d099b7172R64-R67): Updated two PodAntiAffinity tests to skip execution on CRC clusters. [[1]](diffhunk://#diff-f513dd31a32dd37da5db58189089864dbe14ad5360a891d8e31e077d099b7172R64-R67) [[2]](diffhunk://#diff-f513dd31a32dd37da5db58189089864dbe14ad5360a891d8e31e077d099b7172R155-R158)
* [`tests/lifecycle/tests/lifecycle_statefulset_scaling.go`](diffhunk://#diff-064f101c3ca95e17f76d59d7775845368f3197df3cbc99d7b4b183bc79e65d3aR63-R66): Added a check to skip the StatefulSet scaling test on CRC clusters.