### PR TITLE
Skip these intrusive tests on CRC environments

### DIFF
--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -2,8 +2,8 @@
 name: QE OCP Testing (Ubuntu-hosted)
 
 on:
-  pull_request:
-    branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
   workflow_dispatch:
   # Schedule a daily cron at midnight UTC
   schedule:

--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -2,8 +2,8 @@
 name: QE Testing (Ubuntu-hosted)
 
 on:
-  # pull_request:
-  #   branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
   # Schedule a daily cron at midnight UTC
   schedule:

--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -365,3 +365,49 @@ func IsKindCluster() bool {
 
 	return cmd.Run() == nil
 }
+
+// Returns true if the cluster is a CRC (Code Ready Containers) cluster, otherwise false.
+// CRC clusters are typically single-node OpenShift clusters used for development.
+func IsCRCCluster() bool {
+	// Method 1: Check for CRC-specific domain patterns
+	cmd := exec.Command("oc", "cluster-info")
+	output, err := cmd.Output()
+
+	if err == nil {
+		outputStr := string(output)
+		if strings.Contains(outputStr, ".crc.testing") ||
+			strings.Contains(outputStr, "apps-crc.testing") ||
+			strings.Contains(outputStr, "api.crc.testing") {
+			return true
+		}
+	}
+
+	// Method 2: Check if it's a single-node cluster with CRC-like node names
+	nodes, err := GetAPIClient().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return false
+	}
+
+	// CRC typically has exactly one node
+	if len(nodes.Items) == 1 {
+		nodeName := nodes.Items[0].Name
+		// CRC nodes often have names starting with "crc-" followed by random characters
+		if strings.HasPrefix(nodeName, "crc-") && strings.HasSuffix(nodeName, "-master-0") {
+			return true
+		}
+	}
+
+	// Method 3: Check for CRC-specific labels or annotations
+	for _, node := range nodes.Items {
+		if labels := node.Labels; labels != nil {
+			// CRC clusters often have specific labels
+			if labels["node-role.kubernetes.io/master"] == "" && labels["node-role.kubernetes.io/control-plane"] == "" {
+				if len(nodes.Items) == 1 { // Single node with master role suggests CRC
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/tests/lifecycle/tests/lifecycle_deployment_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_deployment_scaling.go
@@ -53,6 +53,9 @@ var _ = Describe("lifecycle-deployment-scaling", Serial, func() {
 
 	// 47398
 	It("One deployment, one pod, one container, scale in and out", func() {
+		if globalhelper.IsCRCCluster() {
+			Skip("Deployment scaling test is not supported on CRC clusters")
+		}
 
 		By("Define Deployment")
 		deploymenta, err := tshelper.DefineDeployment(1, 1, tsparams.TestDeploymentName, randomNamespace)

--- a/tests/lifecycle/tests/lifecycle_pod_recreation.go
+++ b/tests/lifecycle/tests/lifecycle_pod_recreation.go
@@ -61,6 +61,10 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 	// 47405
 	It("One deployment with PodAntiAffinity, replicas are less than schedulable nodes", func() {
+		if globalhelper.IsCRCCluster() {
+			Skip("PodAntiAffinity test is not supported on CRC clusters")
+		}
+
 		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 
@@ -148,6 +152,10 @@ var _ = Describe("lifecycle-pod-recreation", Serial, func() {
 
 	// 47407
 	It("One deployment with PodAntiAffinity, replicas are equal to schedulable nodes [negative]", func() {
+		if globalhelper.IsCRCCluster() {
+			Skip("PodAntiAffinity test is not supported on CRC clusters")
+		}
+
 		schedulableNodes, err := nodes.GetNumOfReadyNodesInCluster(globalhelper.GetAPIClient().Nodes())
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
+++ b/tests/lifecycle/tests/lifecycle_statefulset_scaling.go
@@ -60,6 +60,10 @@ var _ = Describe("lifecycle-statefulset-scaling", Serial, func() {
 
 	// 45439
 	It("One statefulSet, one pod", func() {
+		if globalhelper.IsCRCCluster() {
+			Skip("StatefulSet scaling test is not supported on CRC clusters")
+		}
+
 		By("Define statefulSet")
 		statefulset := tshelper.DefineStatefulSet(tsparams.TestStatefulSetName, randomNamespace)
 


### PR DESCRIPTION
This pull request introduces changes to support CRC (Code Ready Containers) clusters in the testing framework. It includes the addition of a utility function to detect CRC clusters and updates to skip certain tests that are incompatible with CRC clusters. Additionally, a workflow file has been commented out to disable pull request triggers.

### CRC Cluster Support Enhancements:
* [`tests/globalhelper/helper.go`](diffhunk://#diff-e1c500cd9f2c78d57abb90392858cb8048992645b2eb5693eb098951dff49adaR368-R412): Added a new function `IsCRCCluster()` to detect CRC clusters using multiple methods, including domain patterns, node configurations, and labels.

### Test Adjustments for CRC Compatibility:
* [`tests/lifecycle/tests/lifecycle_deployment_scaling.go`](diffhunk://#diff-130e6ce5d8e09b25db8a15193eab1e4909d123386c65f35ffcd78e5b8c7f5571R56-R58): Updated the deployment scaling test to skip execution on CRC clusters using the `IsCRCCluster()` function.
* [`tests/lifecycle/tests/lifecycle_pod_recreation.go`](diffhunk://#diff-f513dd31a32dd37da5db58189089864dbe14ad5360a891d8e31e077d099b7172R64-R67): Updated two PodAntiAffinity tests to skip execution on CRC clusters using the `IsCRCCluster()` function. [[1]](diffhunk://#diff-f513dd31a32dd37da5db58189089864dbe14ad5360a891d8e31e077d099b7172R64-R67) [[2]](diffhunk://#diff-f513dd31a32dd37da5db58189089864dbe14ad5360a891d8e31e077d099b7172R155-R158)
* [`tests/lifecycle/tests/lifecycle_statefulset_scaling.go`](diffhunk://#diff-064f101c3ca95e17f76d59d7775845368f3197df3cbc99d7b4b183bc79e65d3aR63-R66): Updated the StatefulSet scaling test to skip execution on CRC clusters using the `IsCRCCluster()` function.

### Workflow Updates:
* [`.github/workflows/qe-ocp.yml`](diffhunk://#diff-c13b14c9b655fb5672a795fc5e1c27be6d66587dfa15f814f0ccf78e4a50277fL5-R6): Commented out the `pull_request` trigger to disable automatic testing on pull requests for the QE OCP workflow.