### PR TITLE
Replace busted operators

### DIFF
--- a/.github/workflows/pull-images.yml
+++ b/.github/workflows/pull-images.yml
@@ -43,6 +43,6 @@ jobs:
           podman pull --authfile /home/runner/pull-secret.txt registry.redhat.io/openshift4/dpdk-base-rhel8:v4.9
           podman pull --authfile /home/runner/pull-secret.txt registry.connect.redhat.com/cockroachdb/cockroach:v23.1.17
           podman pull --authfile /home/runner/pull-secret.txt registry.access.redhat.com/ubi8/nodejs-12:latest
-          podman pull --authfile /home/runner/pull-secret.txt quay.io/nginx/nginx-ingress-operator@sha256:38bb2a104462808eb800445db354535151fbe2632931b9c2a56da3a526923605
+          podman pull --authfile /home/runner/pull-secret.txt quay.io/grafana/grafana-operator:v5.18.0
           podman pull --authfile /home/runner/pull-secret.txt registry.connect.redhat.com/anchore/engine-operator-bundle@sha256:fbbe7e6c1d75c4de2f47e2c825c930568e85f1134545e9d890a0c9f3d9187a4d
           podman pull --authfile /home/runner/pull-secret.txt registry.redhat.io/quay/quay-operator-rhel8@sha256:59c6daa886c01039cb96da04ae250e0e9b89c73dbd7ece934cf8bf9e9f529812

--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -2,8 +2,8 @@
 name: QE OCP Testing (Ubuntu-hosted)
 
 on:
-  # pull_request:
-  #   branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
   # Schedule a daily cron at midnight UTC
   schedule:
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+        # suite: [operator]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -49,7 +49,7 @@ function run_tests {
 		fi
 		echo "Running tests in the following folders: ${all_default_suites}"
 		# shellcheck disable=SC2086
-		ginkgo -timeout=24h -v ${PFLAG} ${FFLAG} --keep-going "${GINKGO_SEED_FLAG}" --require-suite -r $all_default_suites
+		ginkgo -timeout=24h -v ${PFLAG} ${FFLAG} --keep-going "${GINKGO_SEED_FLAG}" --show-node-events --require-suite -r $all_default_suites
 		;;
 	features)
 		if [ -z "$FEATURES" ]; then
@@ -74,7 +74,7 @@ function run_tests {
 		fi
 
 		# shellcheck disable=SC2086
-		ginkgo -v ${PFLAG} ${FFLAG} --keep-going ${GINKGO_SEED_FLAG} --output-interceptor-mode=none --timeout=24h --require-suite $command
+		ginkgo -v ${PFLAG} ${FFLAG} --keep-going ${GINKGO_SEED_FLAG} --output-interceptor-mode=none --timeout=24h --show-node-events --require-suite $command
 		;;
 	*)
 		echo "Unknown case"

--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -57,7 +57,7 @@ var (
 	OperatorLabel                             = map[string]string{"redhat-best-practices-for-k8s.com/operator": "target"}
 	UncertifiedOperatorPrefixCockroach        = "cockroachdb"
 	CertifiedOperatorPrefixCockroachCertified = "cockroach-operator"
-	CertifiedOperatorPrefixNginx              = "nginx-ingress-operator"
+	CertifiedOperatorPrefix                   = "grafana-operator"
 	UncertifiedOperatorPrefixSriov            = "sriov-fec"
 	UncertifiedOperatorFullSriov              = "sriov-fec.v1.2.1"
 )

--- a/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
@@ -23,6 +23,7 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 	var randomNamespace string
 	var randomReportDir string
 	var randomCertsuiteConfigDir string
+	var grafanaOperatorName string
 
 	BeforeEach(func() {
 		if globalhelper.IsKindCluster() {
@@ -39,35 +40,41 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 			randomCertsuiteConfigDir,
 		)
 
-		By("Query the packagemanifest for the default channel")
-		channel, err := globalhelper.QueryPackageManifestForDefaultChannel(
-			tsparams.CertifiedOperatorPrefixNginx,
-			randomNamespace,
-		)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		By("Query the packagemanifest for Grafana operator package name and catalog source")
+		var catalogSource string
+		var err error
+		grafanaOperatorName, catalogSource, err = globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
+			"grafana", randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
+		Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
+		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
 
-		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)
-		version, err := globalhelper.QueryPackageManifestForVersion(tsparams.CertifiedOperatorPrefixNginx, randomNamespace, channel)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
+		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
+			grafanaOperatorName, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
+		Expect(channel).ToNot(Equal("not found"), "Channel not found")
+		Expect(version).ToNot(Equal("not found"), "Version not found")
+		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
 
-		By(fmt.Sprintf("Deploy nginx-ingress-operator%s for testing", "."+version))
-		// nginx-ingress-operator: in certified-operators group and version is certified
+		By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
+		// grafana-operator: in community-operators group
 		err = tshelper.DeployOperatorSubscription(
-			tsparams.CertifiedOperatorPrefixNginx,
-			tsparams.CertifiedOperatorPrefixNginx,
+			grafanaOperatorName,
+			grafanaOperatorName,
 			channel,
 			randomNamespace,
-			tsparams.CertifiedOperatorGroup,
+			catalogSource,
 			tsparams.OperatorSourceNamespace,
-			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			csvName,
 			v1alpha1.ApprovalAutomatic,
 		)
 		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
-			tsparams.CertifiedOperatorPrefixNginx)
+			grafanaOperatorName)
 
-		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx,
+		err = waitUntilOperatorIsReady(grafanaOperatorName,
 			randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+".v"+version+
+		Expect(err).ToNot(HaveOccurred(), "Operator "+csvName+
 			" is not ready")
 
 		// sriov-fec.v1.1.0 operator : in certified-operators group, version is not certified
@@ -179,11 +186,11 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
-				tsparams.CertifiedOperatorPrefixNginx,
+				grafanaOperatorName,
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+			ErrorLabelingOperatorStr+grafanaOperatorName)
 
 		By("Start test")
 		err := globalhelper.LaunchTests(

--- a/tests/globalhelper/packagemanifest.go
+++ b/tests/globalhelper/packagemanifest.go
@@ -2,6 +2,7 @@ package globalhelper
 
 import (
 	"fmt"
+	"strings"
 
 	egiClients "github.com/openshift-kni/eco-goinfra/pkg/clients"
 	egiOLM "github.com/openshift-kni/eco-goinfra/pkg/olm"
@@ -58,4 +59,117 @@ func QueryPackageManifestForDefaultChannel(operatorName, operatorNamespace strin
 	}
 
 	return "not found", nil
+}
+
+// QueryPackageManifestForOperatorName searches for packages containing the specified search string
+// and returns the first matching package name. This is useful for finding operators whose
+// package names may vary between OCP versions (e.g., "cloudbees-ci" vs "cloudbees-ci-rhmp").
+func QueryPackageManifestForOperatorName(searchString, operatorNamespace string) (string, error) {
+	pkgManifest, err := egiOLM.ListPackageManifest(egiClients.New(""), operatorNamespace, client.ListOptions{})
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, item := range pkgManifest {
+		if strings.Contains(item.Object.GetName(), searchString) {
+			fmt.Printf("Found package: %s matching search string: %s\n", item.Object.GetName(), searchString)
+
+			return item.Object.GetName(), nil
+		}
+	}
+
+	return "not found", nil
+}
+
+// QueryPackageManifestForOperatorNameAndCatalogSource searches for packages containing the specified search string
+// and returns both the package name and the catalog source where it was found. This is useful for finding operators whose
+// package names and catalog sources may vary between OCP versions (e.g., "ovms-operator" in "certified-operators"
+// vs "ovms-operator-rhmp" in "redhat-marketplace").
+func QueryPackageManifestForOperatorNameAndCatalogSource(searchString, operatorNamespace string) (string, string, error) {
+	pkgManifest, err := egiOLM.ListPackageManifest(egiClients.New(""), operatorNamespace, client.ListOptions{})
+
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, item := range pkgManifest {
+		if strings.Contains(item.Object.GetName(), searchString) {
+			packageName := item.Object.GetName()
+			catalogSource := item.Object.Status.CatalogSource
+			fmt.Printf("Found package: %s in catalog source: %s matching search string: %s\n", packageName, catalogSource, searchString)
+
+			return packageName, catalogSource, nil
+		}
+	}
+
+	return "not found", "not found", nil
+}
+
+// QueryPackageManifestForAvailableChannelAndVersion searches for an operator and returns the first available channel
+// that has versions, along with a version from that channel. This is more robust than requiring a specific channel.
+func QueryPackageManifestForAvailableChannelAndVersion(operatorName, operatorNamespace string) (string, string, error) {
+	pkgManifest, err := egiOLM.ListPackageManifest(egiClients.New(""), operatorNamespace, client.ListOptions{})
+
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, item := range pkgManifest {
+		if item.Object.GetName() == operatorName {
+			// Try the default channel first
+			defaultChannel := item.Object.Status.DefaultChannel
+			fmt.Printf("Default channel for %s: %s\n", operatorName, defaultChannel)
+
+			for _, chanObj := range item.Object.Status.Channels {
+				fmt.Printf("Checking channel %s for %s\n", chanObj.Name, operatorName)
+
+				// Check if this channel has a version available
+				if chanObj.CurrentCSVDesc.Version.String() != "" {
+					channelName := chanObj.Name
+					version := chanObj.CurrentCSVDesc.Version.String()
+					fmt.Printf("Found available channel: %s with version: %s for %s\n", channelName, version, operatorName)
+
+					return channelName, version, nil
+				}
+			}
+		}
+	}
+
+	return "not found", "not found", nil
+}
+
+// QueryPackageManifestForAvailableChannelVersionAndCSV searches for an operator and returns the first available channel
+// that has versions, along with the version and the actual CSV name from that channel. This handles cases where
+// the CSV name doesn't match the package name pattern (e.g., package "ovms-operator-rhmp" has CSV "openvino-operator.v1.2.0").
+func QueryPackageManifestForAvailableChannelVersionAndCSV(operatorName, operatorNamespace string) (string, string, string, error) {
+	pkgManifest, err := egiOLM.ListPackageManifest(egiClients.New(""), operatorNamespace, client.ListOptions{})
+
+	if err != nil {
+		return "", "", "", err
+	}
+
+	for _, item := range pkgManifest {
+		if item.Object.GetName() == operatorName {
+			// Try the default channel first
+			defaultChannel := item.Object.Status.DefaultChannel
+			fmt.Printf("Default channel for %s: %s\n", operatorName, defaultChannel)
+
+			for _, chanObj := range item.Object.Status.Channels {
+				fmt.Printf("Checking channel %s for %s\n", chanObj.Name, operatorName)
+
+				// Check if this channel has a version available
+				if chanObj.CurrentCSVDesc.Version.String() != "" && chanObj.CurrentCSV != "" {
+					channelName := chanObj.Name
+					version := chanObj.CurrentCSVDesc.Version.String()
+					csvName := chanObj.CurrentCSV
+					fmt.Printf("Found available channel: %s with version: %s and CSV: %s for %s\n", channelName, version, csvName, operatorName)
+
+					return channelName, version, csvName, nil
+				}
+			}
+		}
+	}
+
+	return "not found", "not found", "not found", nil
 }

--- a/tests/operator/helper/helper.go
+++ b/tests/operator/helper/helper.go
@@ -148,6 +148,17 @@ func DeployOperatorSubscriptionWithNodeSelector(operatorPackage, channel, namesp
 	return nil
 }
 
+// IsCSVNotSucceeded checks if CSV installation status is not Succeeded.
+func IsCSVNotSucceeded(csvPrefix, namespace string) (bool, error) {
+	csv, err := GetCsvByPrefix(csvPrefix, namespace)
+	if err != nil {
+		return false, err
+	}
+
+	// Return true if CSV is NOT in Succeeded phase
+	return csv.Status.Phase != v1alpha1.CSVPhaseSucceeded, nil
+}
+
 func updateCsv(namespace string, csv *v1alpha1.ClusterServiceVersion) error {
 	_, err := globalhelper.GetAPIClient().ClusterServiceVersions(namespace).Update(
 		context.TODO(), csv, metav1.UpdateOptions{},

--- a/tests/operator/parameters/parameters.go
+++ b/tests/operator/parameters/parameters.go
@@ -34,20 +34,16 @@ var (
 		"app":                  "test",
 	}
 	CertsuiteTargetOperatorLabels             = fmt.Sprintf("%s: %s", "redhat-best-practices-for-k8s.com/operator", "target")
-	CertsuiteTargetCrdFilters                 = []string{"nginxingresses.charts.nginx.org"}
+	CertsuiteTargetCrdFilters                 = []string{"grafanadashboards.grafana.integreatly.org"}
 	OperatorGroupName                         = "operator-test-operator-group"
 	OperatorLabel                             = map[string]string{"redhat-best-practices-for-k8s.com/operator": "target"}
 	CertifiedOperatorGroup                    = "certified-operators"
 	RedhatOperatorGroup                       = "redhat-operators"
 	CommunityOperatorGroup                    = "community-operators"
 	OperatorSourceNamespace                   = "openshift-marketplace"
-	OperatorPrefixCloudbees                   = "cloudbees-ci"
-	OperatorPrefixAnchore                     = "anchore-engine"
-	OperatorPrefixQuay                        = "quay-operator"
+	OperatorPrefixLightweight                 = "jaeger-operator"
 	OperatorPrefixKiali                       = "kiali-operator"
-	OperatorPrefixOpenvino                    = "openvino-operator"
-	CertifiedOperatorPrefixNginx              = "nginx-ingress-operator"
-	SubscriptionNameOpenvino                  = "ovms-operator-subscription"
+	CertifiedOperatorPrefix                   = "grafana-operator"
 	UncertifiedOperatorPrefixCockroach        = "cockroachdb"
 	CertifiedOperatorPrefixCockroachCertified = "cockroach-operator"
 	SingleOrMultiNamespacedOperatorGroup      = "single-or-multi-og"

--- a/tests/operator/tests/operator_bundle_image.go
+++ b/tests/operator/tests/operator_bundle_image.go
@@ -30,7 +30,7 @@ var _ = Describe("Operator bundle count,", Serial, func() {
 			[]string{tsparams.TestPodLabel},
 			[]string{},
 			[]string{},
-			tsparams.CertsuiteTargetCrdFilters, randomCertsuiteConfigDir)
+			[]string{"nginxingresses.charts.nginx.org"}, randomCertsuiteConfigDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -56,30 +56,30 @@ var _ = Describe("Operator bundle count,", Serial, func() {
 		By(fmt.Sprintf("Deploy first operator (nginx-ingress-operator) for testing - channel %s", "new"))
 		err = tshelper.DeployOperatorSubscription(
 			"operator1",
-			tsparams.CertifiedOperatorPrefixNginx,
+			"nginx-ingress-operator",
 			"new",
 			randomNamespace,
 			"custom-catalog",
 			tsparams.OperatorSourceNamespace,
-			tsparams.CertifiedOperatorPrefixNginx+".v3.0.1",
+			"nginx-ingress-operator.v3.0.1",
 			v1alpha1.ApprovalAutomatic,
 		)
 		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
-			tsparams.CertifiedOperatorPrefixNginx)
+			"nginx-ingress-operator")
 
 		By("Wait until operator is ready")
-		err = tshelper.WaitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx, randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+
+		err = tshelper.WaitUntilOperatorIsReady("nginx-ingress-operator", randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Operator "+"nginx-ingress-operator"+
 			" is not ready")
 
 		By("Label operator")
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
-				tsparams.CertifiedOperatorPrefixNginx,
+				"nginx-ingress-operator",
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+			ErrorLabelingOperatorStr+"nginx-ingress-operator")
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/operator/tests/operator_crd_openapi_schema.go
+++ b/tests/operator/tests/operator_crd_openapi_schema.go
@@ -13,7 +13,7 @@ import (
 	tsparams "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/operator/parameters"
 )
 
-var _ = Describe("Operator crd-openapi-schema", func() {
+var _ = Describe("Operator crd-openapi-schema", Serial, func() {
 	var randomNamespace string
 	var randomReportDir string
 	var randomCertsuiteConfigDir string
@@ -44,45 +44,49 @@ var _ = Describe("Operator crd-openapi-schema", func() {
 	})
 
 	It("operator crd is defined with openapi schema", func() {
-		By("Query the packagemanifest for the default channel")
-		channel, err := globalhelper.QueryPackageManifestForDefaultChannel(
-			tsparams.CertifiedOperatorPrefixNginx,
-			randomNamespace,
-		)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		By("Query the packagemanifest for Grafana operator package name and catalog source")
+		grafanaOperatorName, catalogSource, err := globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
+			"grafana", randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
+		Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
+		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
 
-		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)
-		version, err := globalhelper.QueryPackageManifestForVersion(tsparams.CertifiedOperatorPrefixNginx, randomNamespace, channel)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
+		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
+			grafanaOperatorName, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
+		Expect(channel).ToNot(Equal("not found"), "Channel not found")
+		Expect(version).ToNot(Equal("not found"), "Version not found")
+		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
 
-		By(fmt.Sprintf("Deploy nginx-ingress-operator%s for testing", "."+version))
-		// nginx-ingress-operator: in certified-operators group and version is certified
+		By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
+		// grafana-operator: in community-operators group
 		err = tshelper.DeployOperatorSubscription(
-			tsparams.CertifiedOperatorPrefixNginx,
-			tsparams.CertifiedOperatorPrefixNginx,
+			grafanaOperatorName,
+			grafanaOperatorName,
 			channel,
 			randomNamespace,
-			tsparams.CertifiedOperatorGroup,
+			catalogSource,
 			tsparams.OperatorSourceNamespace,
-			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			csvName,
 			v1alpha1.ApprovalAutomatic,
 		)
 		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
-			tsparams.CertifiedOperatorPrefixNginx)
+			grafanaOperatorName)
 
-		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx,
+		err = waitUntilOperatorIsReady(grafanaOperatorName,
 			randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+".v"+version+
+		Expect(err).ToNot(HaveOccurred(), "Operator "+csvName+
 			" is not ready")
 
 		By("Label operator")
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
-				tsparams.CertifiedOperatorPrefixNginx,
+				grafanaOperatorName,
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+			ErrorLabelingOperatorStr+grafanaOperatorName)
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/operator/tests/operator_crd_versioning.go
+++ b/tests/operator/tests/operator_crd_versioning.go
@@ -13,7 +13,7 @@ import (
 	tsparams "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/operator/parameters"
 )
 
-var _ = Describe("Operator crd-versioning,", func() {
+var _ = Describe("Operator crd-versioning,", Serial, func() {
 	var randomNamespace string
 	var randomReportDir string
 	var randomCertsuiteConfigDir string
@@ -44,45 +44,49 @@ var _ = Describe("Operator crd-versioning,", func() {
 	})
 
 	It("operator crd has valid versioning", func() {
-		By("Query the packagemanifest for the default channel")
-		channel, err := globalhelper.QueryPackageManifestForDefaultChannel(
-			tsparams.CertifiedOperatorPrefixNginx,
-			randomNamespace,
-		)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		By("Query the packagemanifest for Grafana operator package name and catalog source")
+		grafanaOperatorName, catalogSource, err := globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
+			"grafana", randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
+		Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
+		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
 
-		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)
-		version, err := globalhelper.QueryPackageManifestForVersion(tsparams.CertifiedOperatorPrefixNginx, randomNamespace, channel)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
+		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
+			grafanaOperatorName, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
+		Expect(channel).ToNot(Equal("not found"), "Channel not found")
+		Expect(version).ToNot(Equal("not found"), "Version not found")
+		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
 
-		By(fmt.Sprintf("Deploy nginx-ingress-operator%s for testing", "."+version))
-		// nginx-ingress-operator: in certified-operators group and version is certified
+		By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
+		// grafana-operator: in community-operators group
 		err = tshelper.DeployOperatorSubscription(
-			tsparams.CertifiedOperatorPrefixNginx,
-			tsparams.CertifiedOperatorPrefixNginx,
+			grafanaOperatorName,
+			grafanaOperatorName,
 			channel,
 			randomNamespace,
-			tsparams.CertifiedOperatorGroup,
+			catalogSource,
 			tsparams.OperatorSourceNamespace,
-			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			csvName,
 			v1alpha1.ApprovalAutomatic,
 		)
 		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
-			tsparams.CertifiedOperatorPrefixNginx)
+			grafanaOperatorName)
 
-		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx,
+		err = waitUntilOperatorIsReady(grafanaOperatorName,
 			randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+".v"+version+
+		Expect(err).ToNot(HaveOccurred(), "Operator "+csvName+
 			" is not ready")
 
 		By("Label operator")
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
-				tsparams.CertifiedOperatorPrefixNginx,
+				grafanaOperatorName,
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+			ErrorLabelingOperatorStr+grafanaOperatorName)
 
 		By("Start test")
 		err = globalhelper.LaunchTests(

--- a/tests/operator/tests/operator_semantic_versioning.go
+++ b/tests/operator/tests/operator_semantic_versioning.go
@@ -13,7 +13,7 @@ import (
 	tsparams "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/operator/parameters"
 )
 
-var _ = Describe("Operator semantic-versioning,", func() {
+var _ = Describe("Operator semantic-versioning,", Serial, func() {
 
 	var randomNamespace string
 	var randomReportDir string
@@ -45,45 +45,49 @@ var _ = Describe("Operator semantic-versioning,", func() {
 	})
 
 	It("operator has semantic versioning", func() {
-		By("Query the packagemanifest for the default channel")
-		channel, err := globalhelper.QueryPackageManifestForDefaultChannel(
-			tsparams.CertifiedOperatorPrefixNginx,
-			randomNamespace,
-		)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		By("Query the packagemanifest for Grafana operator package name and catalog source")
+		grafanaOperatorName, catalogSource, err := globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
+			"grafana", randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
+		Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
+		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
 
-		By("Query the packagemanifest for the " + tsparams.CertifiedOperatorPrefixNginx)
-		version, err := globalhelper.QueryPackageManifestForVersion(tsparams.CertifiedOperatorPrefixNginx, randomNamespace, channel)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for nginx-ingress-operator")
+		By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
+		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
+			grafanaOperatorName, randomNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
+		Expect(channel).ToNot(Equal("not found"), "Channel not found")
+		Expect(version).ToNot(Equal("not found"), "Version not found")
+		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
 
-		By(fmt.Sprintf("Deploy nginx-ingress-operator%s for testing", "."+version))
-		// nginx-ingress-operator: in certified-operators group and version is certified
+		By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
+		// grafana-operator: in community-operators group
 		err = tshelper.DeployOperatorSubscription(
-			tsparams.CertifiedOperatorPrefixNginx,
-			tsparams.CertifiedOperatorPrefixNginx,
+			grafanaOperatorName,
+			grafanaOperatorName,
 			channel,
 			randomNamespace,
-			tsparams.CertifiedOperatorGroup,
+			catalogSource,
 			tsparams.OperatorSourceNamespace,
-			tsparams.CertifiedOperatorPrefixNginx+".v"+version,
+			csvName,
 			v1alpha1.ApprovalAutomatic,
 		)
 		Expect(err).ToNot(HaveOccurred(), ErrorDeployOperatorStr+
-			tsparams.CertifiedOperatorPrefixNginx)
+			grafanaOperatorName)
 
-		err = waitUntilOperatorIsReady(tsparams.CertifiedOperatorPrefixNginx,
+		err = waitUntilOperatorIsReady(grafanaOperatorName,
 			randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Operator "+tsparams.CertifiedOperatorPrefixNginx+".v"+version+
+		Expect(err).ToNot(HaveOccurred(), "Operator "+csvName+
 			" is not ready")
 
 		By("Label operator")
 		Eventually(func() error {
 			return tshelper.AddLabelToInstalledCSV(
-				tsparams.CertifiedOperatorPrefixNginx,
+				grafanaOperatorName,
 				randomNamespace,
 				tsparams.OperatorLabel)
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Not(HaveOccurred()),
-			ErrorLabelingOperatorStr+tsparams.CertifiedOperatorPrefixNginx)
+			ErrorLabelingOperatorStr+grafanaOperatorName)
 
 		By("Start test")
 		err = globalhelper.LaunchTests(


### PR DESCRIPTION
This pull request introduces several updates across workflows, test scripts, and operator-related code, primarily focusing on replacing references to the `nginx-ingress-operator` with the `grafana-operator` and enhancing operator query functionality. Additionally, the changes improve logging and test execution details. Below is a breakdown of the most important changes:

### Workflow Updates
* Replaced the `nginx-ingress-operator` image with the `grafana-operator` image in the `.github/workflows/pull-images.yml` file.
* Enabled the `pull_request` trigger for the `QE OCP Testing` workflow and commented out an unused test suite in the matrix. [[1]](diffhunk://#diff-c13b14c9b655fb5672a795fc5e1c27be6d66587dfa15f814f0ccf78e4a50277fL5-R6) [[2]](diffhunk://#diff-c13b14c9b655fb5672a795fc5e1c27be6d66587dfa15f814f0ccf78e4a50277fR19)

### Test Script Enhancements
* Added the `--show-node-events` flag to `ginkgo` commands in `scripts/run-tests.sh` to improve test debugging by displaying node-level events. [[1]](diffhunk://#diff-8902b2f17efc6ce59c23e4b9b4a2ec63d0a75b95eb642db2de7d4afb843a00b9L52-R52) [[2]](diffhunk://#diff-8902b2f17efc6ce59c23e4b9b4a2ec63d0a75b95eb642db2de7d4afb843a00b9L77-R77)

### Operator Replacement
* Replaced all references to `nginx-ingress-operator` with `grafana-operator` in affiliated certification tests, including operator prefix constants, deployment logic, and test descriptions. [[1]](diffhunk://#diff-e36c540fcae99883e04bee3c6722a13a7aa27ef052d6eae8b6d7ffefddb3deacL60-R60) [[2]](diffhunk://#diff-e1e4be9682ba0d3ed5d1a0a6a35726dd0d840a56d57a75d91c3e0445f0888878R26) [[3]](diffhunk://#diff-e1e4be9682ba0d3ed5d1a0a6a35726dd0d840a56d57a75d91c3e0445f0888878L42-R77) [[4]](diffhunk://#diff-e1e4be9682ba0d3ed5d1a0a6a35726dd0d840a56d57a75d91c3e0445f0888878L182-R193) [[5]](diffhunk://#diff-e043bdac252b83e7bcc62acaa425fee0e0d9b629ee0c0747f948aa487f0d04eaR21) [[6]](diffhunk://#diff-e043bdac252b83e7bcc62acaa425fee0e0d9b629ee0c0747f948aa487f0d04eaL88-R123) [[7]](diffhunk://#diff-e043bdac252b83e7bcc62acaa425fee0e0d9b629ee0c0747f948aa487f0d04eaL201-R210) [[8]](diffhunk://#diff-e043bdac252b83e7bcc62acaa425fee0e0d9b629ee0c0747f948aa487f0d04eaL227-R236) [[9]](diffhunk://#diff-1ee38412e067451aad14706e7511d5ea5c49baf78ff031520bccd4b24a485566L37-R46)

### Operator Query Enhancements
* Added new utility functions in `tests/globalhelper/packagemanifest.go` to query package manifests for operator names, catalog sources, available channels, versions, and CSVs. These functions improve flexibility in handling operator variations across OpenShift versions. [[1]](diffhunk://#diff-9eecb9ae8b9b09c24092a88c675221b8a55716e31926fea163c0bfcc5dcc75dbR5) [[2]](diffhunk://#diff-9eecb9ae8b9b09c24092a88c675221b8a55716e31926fea163c0bfcc5dcc75dbR63-R175)

### Logging Improvements
* Re-enabled and improved logging in `AfterEachCleanupWithRandomNamespace` to print logs from the `certsuite.log` file and ensure proper cleanup of report and config directories.