### PR TITLE
Restrict OCP CI runs from forks

### DIFF
--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   qe-ocp-testing:
     runs-on: ubuntu-24.04
+    # Only run on PRs from the main repository, not from forks
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to ensure that the `qe-ocp-testing` job only runs on pull requests originating from the main repository, not from forks.

* [`.github/workflows/qe-ocp.yml`](diffhunk://#diff-c13b14c9b655fb5672a795fc5e1c27be6d66587dfa15f814f0ccf78e4a50277fR15-R16): Added a conditional check (`if`) to the `qe-ocp-testing` job to prevent it from running on pull requests from forked repositories.