### PR TITLE
Log and Fail() if operator does not exist in packagemanifests

### DIFF
--- a/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_invalid_operator.go
@@ -42,24 +42,14 @@ var _ = Describe("Affiliated-certification invalid operator certification,", Ser
 
 		By("Query the packagemanifest for Grafana operator package name and catalog source")
 		var catalogSource string
-		var err error
-		grafanaOperatorName, catalogSource, err = globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
-			"grafana", randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
-		Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
-		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
+		grafanaOperatorName, catalogSource = globalhelper.CheckOperatorExistsOrFail("grafana", randomNamespace)
 
 		By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
-		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
-			grafanaOperatorName, randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
-		Expect(channel).ToNot(Equal("not found"), "Channel not found")
-		Expect(version).ToNot(Equal("not found"), "Version not found")
-		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
+		channel, version, csvName := globalhelper.CheckOperatorChannelAndVersionOrFail(grafanaOperatorName, randomNamespace)
 
 		By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
 		// grafana-operator: in community-operators group
-		err = tshelper.DeployOperatorSubscription(
+		err := tshelper.DeployOperatorSubscription(
 			grafanaOperatorName,
 			grafanaOperatorName,
 			channel,

--- a/tests/affiliatedcertification/tests/affiliated_certification_operator.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_operator.go
@@ -88,20 +88,11 @@ var _ = Describe("Affiliated-certification operator certification,", Serial, fun
 
 		By("Query the packagemanifest for Grafana operator package name and catalog source")
 		var catalogSource string
-		grafanaOperatorName, catalogSource, err = globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
-			"grafana", randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
-		Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
-		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
+		grafanaOperatorName, catalogSource = globalhelper.CheckOperatorExistsOrFail("grafana", randomNamespace)
 
 		By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
 		var csvName string
-		channel, version, csvName, err = globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
-			grafanaOperatorName, randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
-		Expect(channel).ToNot(Equal("not found"), "Channel not found")
-		Expect(version).ToNot(Equal("not found"), "Version not found")
-		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
+		channel, version, csvName = globalhelper.CheckOperatorChannelAndVersionOrFail(grafanaOperatorName, randomNamespace)
 
 		By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
 		// grafana-operator: in community-operators group

--- a/tests/operator/tests/operator_bundle_image.go
+++ b/tests/operator/tests/operator_bundle_image.go
@@ -53,6 +53,9 @@ var _ = Describe("Operator bundle count,", Serial, func() {
 		err = tshelper.DeployTestOperatorGroup(randomNamespace, false)
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
+		By("Check if nginx-ingress-operator exists in packagemanifests")
+		_, _ = globalhelper.CheckOperatorExistsOrFail("nginx-ingress-operator", randomNamespace)
+
 		By(fmt.Sprintf("Deploy first operator (nginx-ingress-operator) for testing - channel %s", "new"))
 		err = tshelper.DeployOperatorSubscription(
 			"operator1",

--- a/tests/operator/tests/operator_crd_openapi_schema.go
+++ b/tests/operator/tests/operator_crd_openapi_schema.go
@@ -45,23 +45,14 @@ var _ = Describe("Operator crd-openapi-schema", Serial, func() {
 
 	It("operator crd is defined with openapi schema", func() {
 		By("Query the packagemanifest for Grafana operator package name and catalog source")
-		grafanaOperatorName, catalogSource, err := globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
-			"grafana", randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
-		Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
-		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
+		grafanaOperatorName, catalogSource := globalhelper.CheckOperatorExistsOrFail("grafana", randomNamespace)
 
 		By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
-		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
-			grafanaOperatorName, randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
-		Expect(channel).ToNot(Equal("not found"), "Channel not found")
-		Expect(version).ToNot(Equal("not found"), "Version not found")
-		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
+		channel, version, csvName := globalhelper.CheckOperatorChannelAndVersionOrFail(grafanaOperatorName, randomNamespace)
 
 		By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
 		// grafana-operator: in community-operators group
-		err = tshelper.DeployOperatorSubscription(
+		err := tshelper.DeployOperatorSubscription(
 			grafanaOperatorName,
 			grafanaOperatorName,
 			channel,

--- a/tests/operator/tests/operator_crd_versioning.go
+++ b/tests/operator/tests/operator_crd_versioning.go
@@ -45,23 +45,14 @@ var _ = Describe("Operator crd-versioning,", Serial, func() {
 
 	It("operator crd has valid versioning", func() {
 		By("Query the packagemanifest for Grafana operator package name and catalog source")
-		grafanaOperatorName, catalogSource, err := globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
-			"grafana", randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
-		Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
-		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
+		grafanaOperatorName, catalogSource := globalhelper.CheckOperatorExistsOrFail("grafana", randomNamespace)
 
 		By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
-		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
-			grafanaOperatorName, randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
-		Expect(channel).ToNot(Equal("not found"), "Channel not found")
-		Expect(version).ToNot(Equal("not found"), "Version not found")
-		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
+		channel, version, csvName := globalhelper.CheckOperatorChannelAndVersionOrFail(grafanaOperatorName, randomNamespace)
 
 		By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
 		// grafana-operator: in community-operators group
-		err = tshelper.DeployOperatorSubscription(
+		err := tshelper.DeployOperatorSubscription(
 			grafanaOperatorName,
 			grafanaOperatorName,
 			channel,

--- a/tests/operator/tests/operator_install_status.go
+++ b/tests/operator/tests/operator_install_status.go
@@ -40,17 +40,10 @@ var _ = Describe("Operator install-source,", Serial, func() {
 		Expect(err).ToNot(HaveOccurred(), "Error deploying operator group")
 
 		By("Query the packagemanifest for grafana operator package name and catalog source")
-		operatorName, catalogSource, err = globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource("grafana", randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for grafana operator")
-		Expect(operatorName).ToNot(Equal("not found"), "Grafana operator package not found")
-		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
+		operatorName, catalogSource = globalhelper.CheckOperatorExistsOrFail("grafana", randomNamespace)
 
 		By("Query the packagemanifest for available channel, version and CSV for " + operatorName)
-		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(operatorName, randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+operatorName)
-		Expect(channel).ToNot(Equal("not found"), "Channel not found")
-		Expect(version).ToNot(Equal("not found"), "Version not found")
-		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
+		channel, _, csvName := globalhelper.CheckOperatorChannelAndVersionOrFail(operatorName, randomNamespace)
 
 		By("Deploy grafana operator for testing")
 		err = tshelper.DeployOperatorSubscription(

--- a/tests/operator/tests/operator_install_status_no_privileges.go
+++ b/tests/operator/tests/operator_install_status_no_privileges.go
@@ -41,17 +41,10 @@ var _ = Describe("Operator install-status-no-privileges,", Serial, func() {
 
 		// grafana operator has clusterPermissions but no resourceNames
 		By("Query the packagemanifest for grafana operator package name and catalog source")
-		operatorName, catalogSource, err = globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource("grafana", randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for grafana operator")
-		Expect(operatorName).ToNot(Equal("not found"), "Grafana operator package not found")
-		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
+		operatorName, catalogSource = globalhelper.CheckOperatorExistsOrFail("grafana", randomNamespace)
 
 		By("Query the packagemanifest for available channel, version and CSV for " + operatorName)
-		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(operatorName, randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+operatorName)
-		Expect(channel).ToNot(Equal("not found"), "Channel not found")
-		Expect(version).ToNot(Equal("not found"), "Version not found")
-		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
+		channel, _, csvName := globalhelper.CheckOperatorChannelAndVersionOrFail(operatorName, randomNamespace)
 
 		By("Deploy grafana operator for testing")
 		err = tshelper.DeployOperatorSubscription(

--- a/tests/operator/tests/operator_semantic_versioning.go
+++ b/tests/operator/tests/operator_semantic_versioning.go
@@ -46,23 +46,14 @@ var _ = Describe("Operator semantic-versioning,", Serial, func() {
 
 	It("operator has semantic versioning", func() {
 		By("Query the packagemanifest for Grafana operator package name and catalog source")
-		grafanaOperatorName, catalogSource, err := globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
-			"grafana", randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
-		Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
-		Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
+		grafanaOperatorName, catalogSource := globalhelper.CheckOperatorExistsOrFail("grafana", randomNamespace)
 
 		By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
-		channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
-			grafanaOperatorName, randomNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
-		Expect(channel).ToNot(Equal("not found"), "Channel not found")
-		Expect(version).ToNot(Equal("not found"), "Version not found")
-		Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
+		channel, version, csvName := globalhelper.CheckOperatorChannelAndVersionOrFail(grafanaOperatorName, randomNamespace)
 
 		By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
 		// grafana-operator: in community-operators group
-		err = tshelper.DeployOperatorSubscription(
+		err := tshelper.DeployOperatorSubscription(
 			grafanaOperatorName,
 			grafanaOperatorName,
 			channel,

--- a/tests/operator/tests/operator_single_or_multi_namespaced_allowed_in_tenant_namespaces.go
+++ b/tests/operator/tests/operator_single_or_multi_namespaced_allowed_in_tenant_namespaces.go
@@ -390,22 +390,13 @@ func createTestOperatorGroup(namespace, operatorGroupName string, targetNamespac
 
 func installAndLabelOperator(operatorNamespace string) {
 	By("Query the packagemanifest for Grafana operator package name and catalog source")
-	grafanaOperatorName, catalogSource, err := globalhelper.QueryPackageManifestForOperatorNameAndCatalogSource(
-		"grafana", operatorNamespace)
-	Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for Grafana operator")
-	Expect(grafanaOperatorName).ToNot(Equal("not found"), "Grafana operator package not found")
-	Expect(catalogSource).ToNot(Equal("not found"), "Grafana operator catalog source not found")
+	grafanaOperatorName, catalogSource := globalhelper.CheckOperatorExistsOrFail("grafana", operatorNamespace)
 
 	By("Query the packagemanifest for available channel, version and CSV for " + grafanaOperatorName)
-	channel, version, csvName, err := globalhelper.QueryPackageManifestForAvailableChannelVersionAndCSV(
-		grafanaOperatorName, operatorNamespace)
-	Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+grafanaOperatorName)
-	Expect(channel).ToNot(Equal("not found"), "Channel not found")
-	Expect(version).ToNot(Equal("not found"), "Version not found")
-	Expect(csvName).ToNot(Equal("not found"), "CSV name not found")
+	channel, version, csvName := globalhelper.CheckOperatorChannelAndVersionOrFail(grafanaOperatorName, operatorNamespace)
 
 	By(fmt.Sprintf("Deploy Grafana operator (channel %s, version %s) for testing", channel, version))
-	err = tshelper.DeployOperatorSubscription(
+	err := tshelper.DeployOperatorSubscription(
 		grafanaOperatorName,
 		grafanaOperatorName,
 		channel,


### PR DESCRIPTION
We should fail out before attempting to spawn operators that don't exist in catalog sources.  This will make problems easier to diagnose.