### PR TITLE
Fix context lint failure

### DIFF
--- a/tests/globalhelper/catalogsources.go
+++ b/tests/globalhelper/catalogsources.go
@@ -25,7 +25,7 @@ func validateCatalogSources(opclient v1alpha1typed.OperatorsV1alpha1Interface) e
 	validCatalogSources := []string{"certified-operators", "community-operators"}
 
 	catalogSources, err := opclient.CatalogSources(
-		CatalogSourceNamespace).List(context.Background(),
+		CatalogSourceNamespace).List(context.TODO(),
 		metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func createCatalogSource(name, url string) error {
 }
 
 func createCatalogSourceWithClient(opclient v1alpha1typed.OperatorsV1alpha1Interface, name, url string) error {
-	_, err := opclient.CatalogSources(CatalogSourceNamespace).Create(context.Background(), &v1alpha1.CatalogSource{
+	_, err := opclient.CatalogSources(CatalogSourceNamespace).Create(context.TODO(), &v1alpha1.CatalogSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: CatalogSourceNamespace,

--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -358,7 +358,7 @@ func GenerateRandomString(length int) string {
 // gains are achievable by invoking the command once, leveraging a
 // synchronization mechanism like sync.Once.
 func IsKindCluster() bool {
-	cmd := exec.Command(
+	cmd := exec.CommandContext(context.TODO(),
 		"oc",
 		"cluster-info", "--context", "kind-kind",
 		">/dev/null", "2>&1")
@@ -370,7 +370,7 @@ func IsKindCluster() bool {
 // CRC clusters are typically single-node OpenShift clusters used for development.
 func IsCRCCluster() bool {
 	// Method 1: Check for CRC-specific domain patterns
-	cmd := exec.Command("oc", "cluster-info")
+	cmd := exec.CommandContext(context.TODO(), "oc", "cluster-info")
 	output, err := cmd.Output()
 
 	if err == nil {

--- a/tests/globalhelper/installplans.go
+++ b/tests/globalhelper/installplans.go
@@ -14,7 +14,7 @@ func CreateInstallPlan(plan *v1alpha1.InstallPlan) error {
 }
 
 func createInstallPlan(plan *v1alpha1.InstallPlan, opclient v1alpha1typed.OperatorsV1alpha1Interface) error {
-	_, err := opclient.InstallPlans(plan.Namespace).Create(context.Background(), plan, metav1.CreateOptions{})
+	_, err := opclient.InstallPlans(plan.Namespace).Create(context.TODO(), plan, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
 		return nil
 	}

--- a/tests/globalhelper/nodes.go
+++ b/tests/globalhelper/nodes.go
@@ -111,7 +111,7 @@ func IsClusterOvercommitted() (bool, error) {
 }
 
 func isClusterOvercommitted(client corev1Typed.NodeInterface) (bool, error) {
-	nodes, err := client.List(context.Background(), metav1.ListOptions{})
+	nodes, err := client.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -1,6 +1,7 @@
 package globalhelper
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -44,7 +45,7 @@ func launchTestsViaBinary(testCaseName string, tcNameForReport string, reportDir
 		"--sanitize-claim", "true",
 	}
 
-	cmd := exec.Command(fmt.Sprintf("%s/%s", GetConfiguration().General.CertsuiteRepoPath,
+	cmd := exec.CommandContext(context.TODO(), fmt.Sprintf("%s/%s", GetConfiguration().General.CertsuiteRepoPath,
 		GetConfiguration().General.CertsuiteEntryPointBinary))
 	cmd.Args = append(cmd.Args, testArgs...)
 
@@ -109,7 +110,7 @@ func launchTestsViaImage(testCaseName string, tcNameForReport string, reportDir 
 	// print the command
 	glog.V(5).Info(fmt.Sprintf("Running command: %s %s", containerEngine, strings.Join(certsuiteCmdArgs, " ")))
 
-	cmd := exec.Command(containerEngine, certsuiteCmdArgs...)
+	cmd := exec.CommandContext(context.TODO(), containerEngine, certsuiteCmdArgs...)
 
 	debugCertsuite, err := GetConfiguration().DebugCertsuite()
 	if err != nil {

--- a/tests/globalhelper/storageclasses.go
+++ b/tests/globalhelper/storageclasses.go
@@ -31,7 +31,7 @@ func createStorageClass(client storagev1typed.StorageV1Interface, storageClassNa
 		}
 	}
 
-	_, err := client.StorageClasses().Create(context.Background(),
+	_, err := client.StorageClasses().Create(context.TODO(),
 		&storageClassTemplate, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
@@ -48,7 +48,7 @@ func DeleteStorageClass(storageClassName string) error {
 }
 
 func deleteStorageClass(client storagev1typed.StorageV1Interface, storageClassName string) error {
-	err := client.StorageClasses().Delete(context.Background(),
+	err := client.StorageClasses().Delete(context.TODO(),
 		storageClassName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)})
 
 	if k8serrors.IsNotFound(err) {


### PR DESCRIPTION
Fixes some linting failures with the new version of golangci-lint.

### Refactoring for subprocess management:

* `tests/globalhelper/helper.go`:
  - Updated `IsKindCluster` to use `exec.CommandContext` with `context.Background()` instead of `exec.Command`.
  - Updated `IsCRCCluster` to use `exec.CommandContext` with `context.Background()` instead of `exec.Command`.

* `tests/globalhelper/runhelper.go`:
  - Imported the `context` package to enable the use of `context.Background()`.
  - Updated `launchTestsViaBinary` to use `exec.CommandContext` with `context.Background()` instead of `exec.Command`.
  - Updated `launchTestsViaImage` to use `exec.CommandContext` with `context.Background()` instead of `exec.Command`.