### PR TITLE
Additional < OCP 4.16 operator fixes

### DIFF
--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -28,6 +28,8 @@ jobs:
       DOCKER_CONFIG_DIR: '/home/runner/.docker/'
       SKIP_PRELOAD_IMAGES: true # Not needed for github-hosted runs
       TEST_REPO: redhat-best-practices-for-k8s/certsuite
+      # Enable infrastructure tolerations for better test reliability in CI environments
+      ENABLE_INFRASTRUCTURE_TOLERATIONS: true
 
     steps:
       - name: Write temporary docker file

--- a/tests/networking/helper/helper.go
+++ b/tests/networking/helper/helper.go
@@ -343,7 +343,7 @@ func defineDaemonSetBasedOnArgs(nadName, namespace, daemonsetName string, labels
 	daemonset.RedefineDaemonSetWithNodeSelector(testDaemonset, map[string]string{globalhelper.GetConfiguration().General.CnfNodeLabel: ""})
 
 	if labels != nil {
-		daemonset.RedefineDaemonSetWithLabel(testDaemonset, labels)
+		daemonset.RedefineWithLabel(testDaemonset, labels)
 	}
 
 	return globalhelper.CreateAndWaitUntilDaemonSetIsReady(testDaemonset, tsparams.WaitingTime)

--- a/tests/operator/tests/operator_install_source.go
+++ b/tests/operator/tests/operator_install_source.go
@@ -14,9 +14,7 @@ import (
 )
 
 const (
-	ErrorDeployOperatorStr   = "Error deploying operator "
-	ErrorLabelingOperatorStr = "Error labeling operator "
-	ErrorRemovingLabelStr    = "Error removing label from operator "
+	ErrorRemovingLabelStr = "Error removing label from operator "
 )
 
 var _ = Describe("Operator install-source,", Serial, func() {

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -39,6 +39,9 @@ type Config struct {
 		DisableIntrusiveTests     string `yaml:"disable_intrusive_tests" envconfig:"DISABLE_INTRUSIVE_TESTS"`
 		ContainerEngine           string `default:"docker" yaml:"container_engine" envconfig:"CONTAINER_ENGINE"`
 		UseBinary                 string `default:"false" yaml:"use_binary" envconfig:"USE_BINARY"`
+		// EnableInfraTolerations enables tolerations for infrastructure taints
+		// (disk-pressure, memory-pressure, etc.) to improve test reliability in CI environments
+		EnableInfraTolerations string `default:"true" yaml:"enable_infrastructure_tolerations" envconfig:"ENABLE_INFRASTRUCTURE_TOLERATIONS"`
 	} `yaml:"general"`
 }
 

--- a/tests/utils/daemonset/daemonset_test.go
+++ b/tests/utils/daemonset/daemonset_test.go
@@ -34,9 +34,9 @@ func TestRedefineDaemonSetWithNodeSelector(t *testing.T) {
 	assert.Equal(t, "", ds.Spec.Template.Spec.NodeSelector["node-role.kubernetes.io/master"])
 }
 
-func TestRedefineDaemonSetWithLabel(t *testing.T) {
+func TestRedefineWithLabel(t *testing.T) {
 	ds := DefineDaemonSet("default", "nginx", map[string]string{"app": "nginx"}, "nginx")
-	RedefineDaemonSetWithLabel(ds, map[string]string{"app": "nginx"})
+	RedefineWithLabel(ds, map[string]string{"app": "nginx"})
 	assert.Equal(t, "nginx", ds.Spec.Template.Labels["app"])
 }
 


### PR DESCRIPTION
This pull request introduces enhancements to the operator installation tests, focusing on improving debugging capabilities, refining test constraints, and consolidating error constants. The most significant changes include adding detailed logging for debugging, strengthening nodeSelector constraints for negative test scenarios, and refactoring error constants for consistency.

### Debugging Enhancements:
* Added extensive debug logging to verify nodeSelector constraints and cluster nodes, including detailed inspection of Jaeger operator CSV status and deployment details. (`tests/operator/tests/operator_install_status.go`, [tests/operator/tests/operator_install_status.goR254-R303](diffhunk://#diff-d39283be7d72d990ab78cc41f2836714fddd203100a9bf56769941b90c602c56R254-R303))

### Test Constraints:
* Strengthened nodeSelector constraints in the negative test to ensure operator installation failure, with additional constraints applied for older OpenShift versions (OCP 4.16 and below). (`tests/operator/tests/operator_install_status.go`, [tests/operator/tests/operator_install_status.goL207-R237](diffhunk://#diff-d39283be7d72d990ab78cc41f2836714fddd203100a9bf56769941b90c602c56L207-R237))

### Code Refactoring:
* Refactored error constants by consolidating them into a single location for better maintainability. (`tests/operator/tests/operator_install_source.go`, [[1]](diffhunk://#diff-e8867c39264d509c16ae1e3fa0300bd7df206d8dfa146fbc10209e99514156c1L17-L18); `tests/operator/tests/operator_install_status.go`, [[2]](diffhunk://#diff-d39283be7d72d990ab78cc41f2836714fddd203100a9bf56769941b90c602c56R4-R22)

### Test Behavior:
* Temporarily focused a specific test case by marking it with `FIt` to facilitate debugging and targeted execution. (`tests/operator/tests/operator_install_status.go`, [tests/operator/tests/operator_install_status.goL187-R196](diffhunk://#diff-d39283be7d72d990ab78cc41f2836714fddd203100a9bf56769941b90c602c56L187-R196))