### PR TITLE
Add tolerations into default DefineXYZ() calls

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -7,6 +7,10 @@ name: Test Incoming Changes
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -15,6 +15,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   qe-ocp-testing:
     runs-on: ubuntu-24.04

--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -14,11 +14,55 @@ on:
   # Schedule a daily cron at midnight UTC
   schedule:
     - cron: '0 0 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   TEST_REPO: redhat-best-practices-for-k8s/certsuite
 
 jobs:
+  build-and-store-binary:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Clone the certsuite repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ env.TEST_REPO }}
+          path: certsuite
+          ref: main
+
+      - name: Extract dependent Pull Requests
+        uses: depends-on/depends-on-action@61cb3f4a0e2c8ae4b90c9448dc57c7ba9ca24c35 # main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          extra-dirs: certsuite
+
+      - name: Build the certsuite binary
+        run: make build-certsuite-tool
+        working-directory: certsuite
+
+      - name: Upload certsuite binary as artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: certsuite-binary
+          path: certsuite/certsuite
+          retention-days: 1
+
   qe-testing:
+    needs: build-and-store-binary
+    if: ${{ needs.build-and-store-binary.result == 'success' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -99,6 +143,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           extra-dirs: certsuite-sample-workload certsuite
 
+      - name: Download pre-built certsuite binary
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: certsuite-binary
+          path: certsuite/
+
+      - name: Make binary executable
+        run: chmod +x certsuite/certsuite
+
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
@@ -107,10 +160,6 @@ jobs:
           command: FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE}/certsuite CERTSUITE_IMAGE=${{env.TEST_CERTSUITE_IMAGE_NAME}} CERTSUITE_IMAGE_TAG=${{env.TEST_CERTSUITE_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true JOB_ID=${{github.run_id}} make test-features
 
       # Only run against the binary during a scheduled run
-      - name: Build the binary
-        run: make build-certsuite-tool
-        working-directory: certsuite
-
       - name: Run the tests (against binary)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:

--- a/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_container_is_certified_digest.go
@@ -19,6 +19,10 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 	var randomCertsuiteConfigDir string
 
 	BeforeEach(func() {
+		if globalhelper.IsKindCluster() {
+			Skip("Skip test due to image pull missing credentials in Kind")
+		}
+
 		// Create random namespace and keep original report and certsuite config directories
 		randomNamespace, randomReportDir, randomCertsuiteConfigDir =
 			globalhelper.BeforeEachSetupWithRandomNamespace(
@@ -52,10 +56,6 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 
 	// 66765
 	It("one container to test, container is certified digest", func() {
-		if globalhelper.IsKindCluster() {
-			Skip("Skip test due to image pull missing credentials in Kind")
-		}
-
 		By("Define deployment with certified container")
 		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.CertifiedContainerURLNodeJs, tsparams.TestDeploymentLabels)
@@ -103,10 +103,6 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 
 	// 66767
 	It("two containers to test, both are certified digest", func() {
-		if globalhelper.IsKindCluster() {
-			Skip("Skip test due to image pull missing credentials in Kind")
-		}
-
 		By("Define deployments with certified containers")
 		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.CertifiedContainerURLNodeJs, tsparams.TestDeploymentLabels)
@@ -137,10 +133,6 @@ var _ = Describe("Affiliated-certification container-is-certified-digest,", Seri
 
 	// 66768
 	It("two containers to test, one is certified, one is not digest [negative]", func() {
-		if globalhelper.IsKindCluster() {
-			Skip("Skip test due to image pull missing credentials in Kind")
-		}
-
 		By("Define deployments with different container certification statuses")
 		dep := deployment.DefineDeployment("affiliated-cert-deployment", randomNamespace,
 			tsparams.UncertifiedContainerURLCnfTest, tsparams.TestDeploymentLabels)

--- a/tests/affiliatedcertification/tests/affiliated_certification_helm_version.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_helm_version.go
@@ -16,6 +16,10 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, func() {
 	var randomCertsuiteConfigDir string
 
 	BeforeEach(func() {
+		if globalhelper.IsKindCluster() {
+			Skip("Skipping helm version test on Kind cluster")
+		}
+
 		// Create random namespace and keep original report and certsuite config directories
 		randomNamespace, randomReportDir, randomCertsuiteConfigDir =
 			globalhelper.BeforeEachSetupWithRandomNamespace(
@@ -38,10 +42,6 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, func() {
 
 	// 68120
 	It("installed helm version is certified", func() {
-		if globalhelper.IsKindCluster() {
-			Skip("Skipping helm version test on Kind cluster")
-		}
-
 		By("Check if helm is installed")
 		cmd := exec.Command("/bin/bash", "-c",
 			"helm version")
@@ -74,10 +74,6 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, func() {
 
 	// 68121
 	It("installed helm version is not certified", func() {
-		if globalhelper.IsKindCluster() {
-			Skip("Skipping helm version test on Kind cluster")
-		}
-
 		By("Remove helm")
 		cmd := exec.Command("sudo", "rm", "-rf", "/usr/local/bin/helm")
 		err := cmd.Run()

--- a/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
+++ b/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
@@ -17,6 +17,10 @@ var _ = Describe("Affiliated-certification helm chart certification,", Serial, f
 	var randomCertsuiteConfigDir string
 
 	BeforeEach(func() {
+		if globalhelper.IsKindCluster() {
+			Skip("Skipping helm chart test on Kind cluster")
+		}
+
 		// Create random namespace and keep original report and certsuite config directories
 		randomNamespace, randomReportDir, randomCertsuiteConfigDir =
 			globalhelper.BeforeEachSetupWithRandomNamespace(
@@ -38,10 +42,6 @@ var _ = Describe("Affiliated-certification helm chart certification,", Serial, f
 	})
 
 	It("One helm to test, are certified", func() {
-		if globalhelper.IsKindCluster() {
-			Skip("Skipping helm chart test on Kind cluster")
-		}
-
 		By("Check if helm is installed")
 		cmd := exec.Command("/bin/bash", "-c",
 			"helm version")
@@ -107,10 +107,6 @@ var _ = Describe("Affiliated-certification helm chart certification,", Serial, f
 	})
 
 	It("One helm to test, chart not certified", func() {
-		if globalhelper.IsKindCluster() {
-			Skip("Skipping helm chart test on Kind cluster")
-		}
-
 		By("Check if helm is installed")
 		cmd := exec.Command("/bin/bash", "-c",
 			"helm version")

--- a/tests/lifecycle/helper/helper.go
+++ b/tests/lifecycle/helper/helper.go
@@ -38,6 +38,24 @@ func DefineDeployment(replica int32, containers int, name, namespace string) (*a
 	return deploymentStruct, nil
 }
 
+// DefineDeploymentWithoutInfrastructureTolerations defines a deployment without automatic infrastructure tolerations.
+// This is useful for tests that need to verify toleration bypass behavior with clean state.
+func DefineDeploymentWithoutInfrastructureTolerations(replica int32, containers int, name, namespace string) (
+	*appsv1.Deployment, error,
+) {
+	if containers < 1 {
+		return nil, errors.New("invalid containers number")
+	}
+
+	deploymentStruct := deployment.DefineDeploymentWithInfrastructureTolerations(name, namespace,
+		tsparams.SampleWorkloadImage, tsparams.TestTargetLabels, false)
+
+	globalhelper.AppendContainersToDeployment(deploymentStruct, containers-1, tsparams.SampleWorkloadImage)
+	deployment.RedefineWithReplicaNumber(deploymentStruct, replica)
+
+	return deploymentStruct, nil
+}
+
 func DefineReplicaSet(name, namespace string) *appsv1.ReplicaSet {
 	return replicaset.DefineReplicaSet(name,
 		namespace,

--- a/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
+++ b/tests/lifecycle/tests/lifecycle_pod_toleration_bypass.go
@@ -39,7 +39,7 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 	// 54984
 	It("one deployment, one pod, no tolerations modified", func() {
 		By("Define deployment with no tolerations modified")
-		dep, err := tshelper.DefineDeployment(1, 1, "lifecycledeployment", randomNamespace)
+		dep, err := tshelper.DefineDeploymentWithoutInfrastructureTolerations(1, 1, "lifecycledeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create deployment")
@@ -137,14 +137,14 @@ var _ = Describe("Lifecycle pod-toleration-bypass", func() {
 	// 54990
 	It("two deployments, one pod each, no tolerations modified", func() {
 		By("Define deployments with no tolerations modified")
-		dep, err := tshelper.DefineDeployment(1, 1, "lifecycledeployment", randomNamespace)
+		dep, err := tshelper.DefineDeploymentWithoutInfrastructureTolerations(1, 1, "lifecycledeployment", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create deployment 1")
 		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.WaitingTime)
 		Expect(err).ToNot(HaveOccurred())
 
-		dep2, err := tshelper.DefineDeployment(1, 1, "lifecycledeployment2", randomNamespace)
+		dep2, err := tshelper.DefineDeploymentWithoutInfrastructureTolerations(1, 1, "lifecycledeployment2", randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Create deployment 2")

--- a/tests/utils/infra/infra.go
+++ b/tests/utils/infra/infra.go
@@ -1,0 +1,18 @@
+package infra
+
+import (
+	"os"
+	"strings"
+)
+
+// ShouldEnableInfrastructureTolerations checks if infrastructure tolerations should be enabled
+// based on environment configuration. Returns true by default if ENABLE_INFRASTRUCTURE_TOLERATIONS
+// is not set or is set to "true".
+func ShouldEnableInfrastructureTolerations() bool {
+	enabled := os.Getenv("ENABLE_INFRASTRUCTURE_TOLERATIONS")
+	if enabled == "" {
+		return true
+	}
+
+	return strings.ToLower(enabled) == "true"
+}

--- a/tests/utils/infra/infra_test.go
+++ b/tests/utils/infra/infra_test.go
@@ -1,0 +1,100 @@
+package infra
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldEnableInfrastructureTolerations(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		envSet      bool
+		expected    bool
+		description string
+	}{
+		{
+			name:        "env_not_set",
+			envSet:      false,
+			expected:    true,
+			description: "should default to true when environment variable is not set",
+		},
+		{
+			name:        "env_empty_string",
+			envValue:    "",
+			envSet:      true,
+			expected:    true,
+			description: "should default to true when environment variable is empty",
+		},
+		{
+			name:        "env_true_lowercase",
+			envValue:    "true",
+			envSet:      true,
+			expected:    true,
+			description: "should return true when set to 'true'",
+		},
+		{
+			name:        "env_true_uppercase",
+			envValue:    "TRUE",
+			envSet:      true,
+			expected:    true,
+			description: "should return true when set to 'TRUE'",
+		},
+		{
+			name:        "env_true_mixedcase",
+			envValue:    "True",
+			envSet:      true,
+			expected:    true,
+			description: "should return true when set to 'True'",
+		},
+		{
+			name:        "env_false_lowercase",
+			envValue:    "false",
+			envSet:      true,
+			expected:    false,
+			description: "should return false when set to 'false'",
+		},
+		{
+			name:        "env_false_uppercase",
+			envValue:    "FALSE",
+			envSet:      true,
+			expected:    false,
+			description: "should return false when set to 'FALSE'",
+		},
+		{
+			name:        "env_random_value",
+			envValue:    "random",
+			envSet:      true,
+			expected:    false,
+			description: "should return false when set to any non-'true' value",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Setup environment
+			const envKey = "ENABLE_INFRASTRUCTURE_TOLERATIONS"
+			oldValue, wasSet := os.LookupEnv(envKey)
+
+			defer func() {
+				if wasSet {
+					t.Setenv(envKey, oldValue)
+				} else {
+					os.Unsetenv(envKey)
+				}
+			}()
+
+			if testCase.envSet {
+				t.Setenv(envKey, testCase.envValue)
+			} else {
+				os.Unsetenv(envKey)
+			}
+
+			// Test the function
+			result := ShouldEnableInfrastructureTolerations()
+			assert.Equal(t, testCase.expected, result, testCase.description)
+		})
+	}
+}

--- a/tests/utils/replicaset/replicaset.go
+++ b/tests/utils/replicaset/replicaset.go
@@ -1,6 +1,7 @@
 package replicaset
 
 import (
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/utils/infra"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,7 +10,7 @@ import (
 
 // DefineReplicaSet returns replicaset struct.
 func DefineReplicaSet(replicaSetName string, namespace string, image string, label map[string]string) *appsv1.ReplicaSet {
-	return &appsv1.ReplicaSet{
+	replicaSet := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      replicaSetName,
 			Namespace: namespace},
@@ -31,6 +32,11 @@ func DefineReplicaSet(replicaSetName string, namespace string, image string, lab
 							Name:    "test",
 							Image:   image,
 							Command: []string{"/bin/bash", "-c", "sleep INF"}}}}}}}
+
+	// Automatically add infrastructure tolerations if enabled
+	RedefineWithInfrastructureTolerationsIfEnabled(replicaSet)
+
+	return replicaSet
 }
 
 // RedefineWithReplicaNumber redefines replicaSet with requested replica number.
@@ -48,5 +54,63 @@ func RedefineWithPVC(replicaSet *appsv1.ReplicaSet, name string, claim string) {
 				},
 			},
 		},
+	}
+}
+
+// RedefineWithInfrastructureTolerations adds tolerations for common infrastructure taints
+// that can occur in test/CI environments. This helps improve test reliability when
+// nodes have transient resource pressure.
+func RedefineWithInfrastructureTolerations(replicaSet *appsv1.ReplicaSet) {
+	infrastructureTolerations := []corev1.Toleration{
+		{
+			Key:      "node.kubernetes.io/disk-pressure",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/memory-pressure",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/pid-pressure",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/network-unavailable",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/unreachable",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoExecute,
+			// Tolerate for a short time to allow for transient network issues
+			TolerationSeconds: ptr.To[int64](30),
+		},
+		{
+			Key:      "node.kubernetes.io/not-ready",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoExecute,
+			// Tolerate for a short time to allow for node startup
+			TolerationSeconds: ptr.To[int64](30),
+		},
+	}
+
+	// Append to existing tolerations rather than replacing them
+	replicaSet.Spec.Template.Spec.Tolerations = append(replicaSet.Spec.Template.Spec.Tolerations, infrastructureTolerations...)
+}
+
+// RedefineWithCustomTolerations adds custom tolerations to the replicaset.
+func RedefineWithCustomTolerations(replicaSet *appsv1.ReplicaSet, tolerations []corev1.Toleration) {
+	replicaSet.Spec.Template.Spec.Tolerations = append(replicaSet.Spec.Template.Spec.Tolerations, tolerations...)
+}
+
+// RedefineWithInfrastructureTolerationsIfEnabled conditionally adds infrastructure tolerations
+// based on configuration. This is the recommended way to apply infrastructure tolerations.
+func RedefineWithInfrastructureTolerationsIfEnabled(replicaSet *appsv1.ReplicaSet) {
+	if infra.ShouldEnableInfrastructureTolerations() {
+		RedefineWithInfrastructureTolerations(replicaSet)
 	}
 }


### PR DESCRIPTION
This pull request introduces a mechanism to automatically add infrastructure tolerations to Kubernetes resources (e.g., DaemonSets, Deployments, Pods, ReplicaSets, StatefulSets) to improve resilience in test/CI environments. It also adds utility functions to conditionally apply these tolerations based on environment configuration. The changes span multiple resource definition utilities and include updates to their return logic.

### Automatic Infrastructure Tolerations

* Added `RedefineWithInfrastructureTolerationsIfEnabled` to conditionally apply infrastructure tolerations based on the `ENABLE_INFRASTRUCTURE_TOLERATIONS` environment variable. This function is now called in the resource creation methods for:
  - `DaemonSet` (`tests/utils/daemonset/daemonset.go`) [[1]](diffhunk://#diff-8afe4df6473ad76ab5306f159e35d1e4e1db323a1ad73ddc27c6e1e1159d39baR37-R48) [[2]](diffhunk://#diff-8afe4df6473ad76ab5306f159e35d1e4e1db323a1ad73ddc27c6e1e1159d39baR68-R72)
  - `Deployment` (`tests/utils/deployment/deployment.go`)
  - `Pod` (`tests/utils/pod/pod.go`)
  - `ReplicaSet` (`tests/utils/replicaset/replicaset.go`)
  - `StatefulSet` (`tests/utils/statefulset/statefulset.go`)

* Introduced `shouldEnableInfrastructureTolerations` to determine whether tolerations should be applied based on the environment configuration (`ENABLE_INFRASTRUCTURE_TOLERATIONS`). Defaults to enabled if the variable is unset. [[1]](diffhunk://#diff-8afe4df6473ad76ab5306f159e35d1e4e1db323a1ad73ddc27c6e1e1159d39baR129-R147) [[2]](diffhunk://#diff-bb0c36450134619ba68e445df4fff17f0619d788fa7a36d405e796a58ffa6bdcR61-R129) [[3]](diffhunk://#diff-b0611f72d11ed035de9a79668021ba09333f5f2e3b43983c153e02fad09cbc3dR134-R152)

### Utility Functions for Tolerations

* Added `RedefineWithInfrastructureTolerations` to append predefined tolerations for common infrastructure taints (e.g., `disk-pressure`, `memory-pressure`, `network-unavailable`). These tolerations improve reliability in environments with transient resource pressure.

### Refactoring of Resource Definitions

* Updated the return logic of resource definition functions (`DefineDaemonSet`, `DefineDeployment`, `DefinePod`, `DefineReplicaSet`, `DefineStatefulSet`) to use intermediate variables (e.g., `daemonSet`, `deployment`) before returning, allowing easier modification (e.g., adding tolerations). [[1]](diffhunk://#diff-8afe4df6473ad76ab5306f159e35d1e4e1db323a1ad73ddc27c6e1e1159d39baL14-R16) [[2]](diffhunk://#diff-c16679d69732c6b67f2ac421d783f83ca3ab992483de94341198a3649ad7faadL22-R22) [[3]](diffhunk://#diff-3940ce372529a3774db43af27422da38b9e3083d0d38fef0235a2593f84c42b1L58-R58) [[4]](diffhunk://#diff-bb0c36450134619ba68e445df4fff17f0619d788fa7a36d405e796a58ffa6bdcL12-R15) [[5]](diffhunk://#diff-b0611f72d11ed035de9a79668021ba09333f5f2e3b43983c153e02fad09cbc3dL13-R16)

### Dependency Updates

* Added imports for `os` and `strings` packages in files where the toleration logic was introduced. These are used for environment variable checks and string operations. [[1]](diffhunk://#diff-8afe4df6473ad76ab5306f159e35d1e4e1db323a1ad73ddc27c6e1e1159d39baR5-R6) [[2]](diffhunk://#diff-bb0c36450134619ba68e445df4fff17f0619d788fa7a36d405e796a58ffa6bdcR4-R6) [[3]](diffhunk://#diff-b0611f72d11ed035de9a79668021ba09333f5f2e3b43983c153e02fad09cbc3dR4-R6)