### PR TITLE
Experiment with smaller uncertified image

### DIFF
--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
-        # suite: [operator]
+        # suite: [affiliatedcertification]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
@@ -81,12 +81,13 @@ jobs:
 
       - name: Setup up OCP cluster
         if: steps.check-secret.outputs.has-secret == 'true'
-        uses: palmsoftware/quick-ocp@v0.0.16
+        uses: palmsoftware/quick-ocp@5eca874ab6dcdf5d32778922904527fb6ba89464
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
           waitForOperatorsReady: true
-          crcMemory: 12000
+          enableMicroshift: true
+          # crcMemory: 12500
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
 

--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -2,14 +2,14 @@
 name: QE Testing (Ubuntu-hosted)
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'tests/**'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/qe-ocp.yml'
-      - '.github/workflows/qe.yml'
+  # pull_request:
+  #   branches: [ main ]
+  #   paths:
+  #     - 'tests/**'
+  #     - 'go.mod'
+  #     - 'go.sum'
+  #     - '.github/workflows/qe-ocp.yml'
+  #     - '.github/workflows/qe.yml'
   workflow_dispatch:
   # Schedule a daily cron at midnight UTC
   schedule:

--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -46,7 +46,7 @@ var (
 	ContainerRepoOnlyRedHatRegistry     = ";registry.connect.redhat.com;;"
 	CertifiedContainerURLNodeJs         = "registry.access.redhat.com/ubi8/nodejs-12:latest"
 	CertifiedContainerURLCockroachDB    = "registry.connect.redhat.com/cockroachdb/cockroach:v23.1.17" // 'latest' tag is not available
-	UncertifiedContainerURLCnfTest      = "quay.io/testnetworkfunction/k8s-best-practices-debug:latest"
+	UncertifiedContainerURLCnfTest      = "quay.io/fedora/fedora-minimal:40"
 
 	TestCaseOperatorAffiliatedCertName        = "affiliated-certification-operator-is-certified"
 	TestHelmChartCertified                    = "affiliated-certification-helmchart-is-certified"

--- a/tests/affiliatedcertification/tests/affiliated_certification_helm_version.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_helm_version.go
@@ -10,16 +10,47 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
-var _ = Describe("Affiliated-certification helm-version,", Serial, func() {
+var _ = Describe("Affiliated-certification helm-version,", Ordered, Serial, func() {
 	var randomNamespace string
 	var randomReportDir string
 	var randomCertsuiteConfigDir string
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		if globalhelper.IsKindCluster() {
 			Skip("Skipping helm version test on Kind cluster")
 		}
 
+		By("Install helm v2 to /usr/local/bin/helm2")
+		cmd := exec.Command("/bin/bash", "-c",
+			"curl -fsSL -o get_helm_v2.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get"+
+				" && chmod +x get_helm_v2.sh"+
+				" && HELM_INSTALL_DIR=/usr/local/bin ./get_helm_v2.sh --version v2.17.0 --no-sudo"+
+				" && mv /usr/local/bin/helm /usr/local/bin/helm2")
+		err := cmd.Run()
+		Expect(err).ToNot(HaveOccurred(), "Error installing helm v2")
+
+		By("Install helm v3 to /usr/local/bin/helm3")
+		cmd = exec.Command("/bin/bash", "-c",
+			"curl -fsSL -o get_helm_v3.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"+
+				" && chmod +x get_helm_v3.sh"+
+				" && HELM_INSTALL_DIR=/usr/local/bin ./get_helm_v3.sh --no-sudo"+
+				" && mv /usr/local/bin/helm /usr/local/bin/helm3")
+		err = cmd.Run()
+		Expect(err).ToNot(HaveOccurred(), "Error installing helm v3")
+
+		By("Create default helm symlink to v3")
+		cmd = exec.Command("/bin/bash", "-c", "ln -sf /usr/local/bin/helm3 /usr/local/bin/helm")
+		err = cmd.Run()
+		Expect(err).ToNot(HaveOccurred(), "Error creating helm symlink")
+	})
+
+	AfterAll(func() {
+		By("Cleanup helm installations")
+		_ = exec.Command("sudo", "rm", "-f", "/usr/local/bin/helm", "/usr/local/bin/helm2", "/usr/local/bin/helm3").Run()
+		_ = exec.Command("rm", "-f", "get_helm_v2.sh", "get_helm_v3.sh").Run()
+	})
+
+	BeforeEach(func() {
 		// Create random namespace and keep original report and certsuite config directories
 		randomNamespace, randomReportDir, randomCertsuiteConfigDir =
 			globalhelper.BeforeEachSetupWithRandomNamespace(
@@ -42,21 +73,15 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, func() {
 
 	// 68120
 	It("installed helm version is certified", func() {
-		By("Check if helm is installed")
-		cmd := exec.Command("/bin/bash", "-c",
-			"helm version")
+		By("Ensure helm points to v3")
+		cmd := exec.Command("/bin/bash", "-c", "ln -sf /usr/local/bin/helm3 /usr/local/bin/helm")
 		err := cmd.Run()
-		if err != nil {
-			Skip("helm does not exist please install it to run the test.")
-		}
+		Expect(err).ToNot(HaveOccurred(), "Error setting helm to v3")
 
-		By("Check that helm version is v3")
-		cmd = exec.Command("/bin/bash", "-c",
-			"helm version --short | grep v3")
+		By("Verify helm version is v3")
+		cmd = exec.Command("/bin/bash", "-c", "helm version --short | grep v3")
 		err = cmd.Run()
-		if err != nil {
-			Fail("Helm version is not v3")
-		}
+		Expect(err).ToNot(HaveOccurred(), "Helm is not v3")
 
 		By("Start test")
 		err = globalhelper.LaunchTests(
@@ -74,32 +99,25 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, func() {
 
 	// 68121
 	It("installed helm version is not certified", func() {
-		By("Remove helm")
-		cmd := exec.Command("sudo", "rm", "-rf", "/usr/local/bin/helm")
+		By("Switch helm to v2")
+		cmd := exec.Command("/bin/bash", "-c", "ln -sf /usr/local/bin/helm2 /usr/local/bin/helm")
 		err := cmd.Run()
-		Expect(err).ToNot(HaveOccurred(), "Error uninstalling helm")
+		Expect(err).ToNot(HaveOccurred(), "Error setting helm to v2")
 
-		By("Install helm v2")
-		cmd = exec.Command("/bin/bash", "-c",
-			"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get"+
-				" && chmod +x get_helm.sh"+
-				" && ./get_helm.sh --version v2.17.0"+
-				" && helm init")
+		By("Initialize tiller for helm v2")
+		cmd = exec.Command("/bin/bash", "-c", "helm init")
 		err = cmd.Run()
-		Expect(err).ToNot(HaveOccurred(), "Error installing helm v2")
+		Expect(err).ToNot(HaveOccurred(), "Error initializing helm v2")
 
 		DeferCleanup(func() {
 			By("Delete tiller from kube-system namespace")
 			err := globalhelper.DeleteDeployment("tiller-deploy", "kube-system")
 			Expect(err).ToNot(HaveOccurred(), "Error deleting tiller deployment")
 
-			By("Re-install helm v3")
-			cmd = exec.Command("/bin/bash", "-c",
-				"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"+
-					" && chmod +x get_helm.sh"+
-					" && ./get_helm.sh")
+			By("Restore helm to v3")
+			cmd = exec.Command("/bin/bash", "-c", "ln -sf /usr/local/bin/helm3 /usr/local/bin/helm")
 			err = cmd.Run()
-			Expect(err).ToNot(HaveOccurred(), "Error installing helm v3")
+			Expect(err).ToNot(HaveOccurred(), "Error restoring helm to v3")
 		})
 
 		By("Start test")

--- a/tests/globalhelper/daemonset.go
+++ b/tests/globalhelper/daemonset.go
@@ -82,6 +82,19 @@ func getDaemonSetPullPolicy(daemonset *appsv1.DaemonSet, client *egiClients.Sett
 	return ds.Object.Spec.Template.Spec.Containers[0].ImagePullPolicy, nil
 }
 
+func GetRunningDaemonsetByName(name, namespace string) (*appsv1.DaemonSet, error) {
+	return getRunningDaemonsetByName(name, namespace, egiClients.New(""))
+}
+
+func getRunningDaemonsetByName(name, namespace string, client *egiClients.Settings) (*appsv1.DaemonSet, error) {
+	ds, err := egiDaemonset.Pull(client, name, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get daemonset %q (ns %s): %w", name, namespace, err)
+	}
+
+	return ds.Object, nil
+}
+
 func GetRunningDaemonset(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 	return getRunningDaemonset(ds, egiClients.New(""))
 }

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -115,15 +115,15 @@ func BeforeEachSetupWithRandomPrivilegedNamespace(incomingNamespace string) (ran
 }
 
 func AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, randomConfigDir string, waitingTime time.Duration) {
-	// logfile := "certsuite.log"
-	// By("Print logs")
-	// myFile, err := os.ReadFile(randomReportDir + "/" + logfile)
-	// if err != nil {
-	// 	glog.Errorf("can not read file %s - %s", logfile, err)
-	// }
-	// fmt.Println(string(myFile))
-	// By(fmt.Sprintf("Remove reports from report directory: %s", randomReportDir))
-	err := RemoveContentsFromReportDir(randomReportDir)
+	logfile := "certsuite.log"
+	By("Print logs")
+	myFile, err := os.ReadFile(randomReportDir + "/" + logfile)
+	if err != nil {
+		glog.Errorf("can not read file %s - %s", logfile, err)
+	}
+	fmt.Println(string(myFile))
+	By(fmt.Sprintf("Remove reports from report directory: %s", randomReportDir))
+	err = RemoveContentsFromReportDir(randomReportDir)
 	Expect(err).ToNot(HaveOccurred())
 
 	By(fmt.Sprintf("Remove configs from config directory: %s", randomConfigDir))

--- a/tests/networking/tests/networking_multus_links.go
+++ b/tests/networking/tests/networking_multus_links.go
@@ -1,6 +1,9 @@
 package tests
 
 import (
+	"encoding/json"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
@@ -35,6 +38,26 @@ var _ = Describe("Networking custom namespace,", func() {
 			randomReportDir, randomCertsuiteConfigDir, tsparams.WaitingTime)
 	})
 
+	// expectNetworksAnnotation asserts that the multus networks annotation exists and
+	// contains exactly the expected NAD names (order-insensitive).
+	expectNetworksAnnotation := func(annotations map[string]string, expectedNadNames []string) {
+		Expect(annotations).To(HaveKey("k8s.v1.cni.cncf.io/networks"))
+		raw := annotations["k8s.v1.cni.cncf.io/networks"]
+		var nets []struct {
+			Name string `json:"name"`
+		}
+		Expect(json.Unmarshal([]byte(raw), &nets)).To(Succeed())
+		got := make([]string, 0, len(nets))
+		for _, n := range nets {
+			got = append(got, n.Name)
+		}
+		// Order-insensitive comparison without varargs conversion complexity
+		Expect(got).To(HaveLen(len(expectedNadNames)))
+		for _, expected := range expectedNadNames {
+			Expect(got).To(ContainElement(expected))
+		}
+	}
+
 	// 48328
 	It("custom deployment 3 pods, 1 NAD, connectivity via Multus secondary interface", func() {
 		By("Define and create Network-attachment-definition")
@@ -46,6 +69,11 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
+
+		// Assert deployment has multus annotation
+		runningDep48328, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(runningDep48328.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -76,10 +104,18 @@ var _ = Describe("Networking custom namespace,", func() {
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
+		depA48330, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depA48330.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
+
 		By("Define second deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
 			tsparams.TestDeploymentBName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
+
+		depB48330, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentBName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depB48330.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -110,10 +146,18 @@ var _ = Describe("Networking custom namespace,", func() {
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
+		depA48331, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depA48331.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
+
 		By("Define second deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
 			tsparams.TestDeploymentBName, randomNamespace, []string{tsparams.TestNadNameB}, 3)
 		Expect(err).ToNot(HaveOccurred())
+
+		depB48331, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentBName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depB48331.Spec.Template.Annotations, []string{tsparams.TestNadNameB})
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -138,6 +182,10 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
+
+		dep48334, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(dep48334.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -168,10 +216,18 @@ var _ = Describe("Networking custom namespace,", func() {
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 1)
 		Expect(err).ToNot(HaveOccurred())
 
+		depA48338, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depA48338.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
+
 		By("Define deployment-b and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
 			tsparams.TestDeploymentBName, randomNamespace, []string{tsparams.TestNadNameB}, 3)
 		Expect(err).ToNot(HaveOccurred())
+
+		depB48338, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentBName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depB48338.Spec.Template.Annotations, []string{tsparams.TestNadNameB})
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -203,10 +259,21 @@ var _ = Describe("Networking custom namespace,", func() {
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
+		dep48343, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(dep48343.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
+
 		By("Define daemonset and create it on cluster")
 
 		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB, randomNamespace, "ds1")
 		Expect(err).ToNot(HaveOccurred())
+
+		// time.Sleep(10 * time.Minute)
+
+		// Assert daemonset is created and has multus annotation
+		daemonset, err := globalhelper.GetRunningDaemonsetByName("ds1", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(daemonset.Spec.Template.Annotations, []string{tsparams.TestNadNameB})
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -233,6 +300,10 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = tshelper.DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA, randomNamespace, "ds2")
 		Expect(err).ToNot(HaveOccurred())
 
+		ds2, err := globalhelper.GetRunningDaemonsetByName("ds2", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(ds2.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.CertsuiteMultusIpv4TcName,
@@ -258,10 +329,18 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = tshelper.DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA, randomNamespace, "ds3")
 		Expect(err).ToNot(HaveOccurred())
 
+		ds3, err := globalhelper.GetRunningDaemonsetByName("ds3", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(ds3.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
+
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusAndSkipLabelOnCluster(
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
+
+		dep48382skip, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(dep48382skip.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -277,7 +356,7 @@ var _ = Describe("Networking custom namespace,", func() {
 	})
 
 	// 48582
-	It("custom deployment and daemonSet 3 pods, daemonSet has skip label", func() {
+	FIt("custom deployment and daemonSet 3 pods, daemonSet has skip label", func() {
 
 		By("Define and create network-attachment-definitions")
 		err := tshelper.DefineAndCreateNadOnCluster(
@@ -288,10 +367,40 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = tshelper.DefineAndCreateDaemonsetWithMultusAndSkipLabelOnCluster(tsparams.TestNadNameA, randomNamespace, "ds4")
 		Expect(err).ToNot(HaveOccurred())
 
+		ds4, err := globalhelper.GetRunningDaemonsetByName("ds4", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(ds4.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
+
 		By("Define deployment and create it on cluster")
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
+
+		dep48382pass, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(dep48382pass.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
+
+		// Verify all of the multus interfaces are setup
+		daemonset, err := globalhelper.GetRunningDaemonsetByName("ds4", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		for _, container := range daemonset.Spec.Template.Spec.Containers {
+			for _, volume := range container.VolumeMounts {
+				Expect(volume.Name).To(Equal("multus-cni-network"))
+			}
+		}
+		deployment, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			for _, volume := range container.VolumeMounts {
+				Expect(volume.Name).To(Equal("multus-cni-network"))
+			}
+		}
+
+		// By("Sleep for 10 minutes")
+
+		// The certsuite requires the network-status annotation to be set in the deployment and daemonset before the test is run.
+
+		time.Sleep(10 * time.Minute)
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -323,6 +432,10 @@ var _ = Describe("Networking custom namespace,", func() {
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA, tsparams.TestNadNameB}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
+		depMulti48582, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depMulti48582.Spec.Template.Annotations, []string{tsparams.TestNadNameA, tsparams.TestNadNameB})
+
 		By("Start tests")
 		err = globalhelper.LaunchTests(
 			tsparams.CertsuiteMultusIpv4TcName,
@@ -349,6 +462,10 @@ var _ = Describe("Networking custom namespace,", func() {
 		err = tshelper.DefineAndCreateDeploymentWithMultusOnCluster(
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
+
+		depNeg48346, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depNeg48346.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
 
 		By("Put one deployment's pod interface down")
 		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"}, randomNamespace)
@@ -384,6 +501,10 @@ var _ = Describe("Networking custom namespace,", func() {
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
+		depNeg48347, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depNeg48347.Spec.Template.Annotations, []string{tsparams.TestNadNameA})
+
 		By("Put one deployment's pod interface down")
 		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -391,6 +512,10 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Define daemonset and create it on cluster")
 		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB, randomNamespace, "ds5")
 		Expect(err).ToNot(HaveOccurred())
+
+		ds5, err := globalhelper.GetRunningDaemonsetByName("ds5", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(ds5.Spec.Template.Annotations, []string{tsparams.TestNadNameB})
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(
@@ -423,6 +548,10 @@ var _ = Describe("Networking custom namespace,", func() {
 			tsparams.TestDeploymentAName, randomNamespace, []string{tsparams.TestNadNameB, tsparams.TestNadNameA}, 3)
 		Expect(err).ToNot(HaveOccurred())
 
+		depNeg48590, err := globalhelper.GetRunningDeployment(randomNamespace, tsparams.TestDeploymentAName)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(depNeg48590.Spec.Template.Annotations, []string{tsparams.TestNadNameA, tsparams.TestNadNameB})
+
 		By("Put one deployment's pod interface down")
 		err = tshelper.ExecCmdOnOnePodInNamespace([]string{"ip", "link", "set", "net1", "down"}, randomNamespace)
 		Expect(err).ToNot(HaveOccurred())
@@ -430,6 +559,10 @@ var _ = Describe("Networking custom namespace,", func() {
 		By("Define daemonset and create it on cluster")
 		err = tshelper.DefineAndCreateDaemonsetWithMultusOnCluster(tsparams.TestNadNameB, randomNamespace, "ds6")
 		Expect(err).ToNot(HaveOccurred())
+
+		ds6, err := globalhelper.GetRunningDaemonsetByName("ds6", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		expectNetworksAnnotation(ds6.Spec.Template.Annotations, []string{tsparams.TestNadNameB})
 
 		By("Start tests")
 		err = globalhelper.LaunchTests(

--- a/tests/utils/daemonset/daemonset.go
+++ b/tests/utils/daemonset/daemonset.go
@@ -162,8 +162,9 @@ func RedefineWithPrivilegeAndHostNetwork(daemonSet *appsv1.DaemonSet) {
 }
 
 func RedefineWithMultus(daemonSet *appsv1.DaemonSet, nadName string) {
+	ns := daemonSet.Spec.Template.Namespace
 	daemonSet.Spec.Template.Annotations = map[string]string{
-		"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[ { "name": "%s" } ]`, nadName),
+		"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[ { "name": "%s", "namespace": "%s" } ]`, nadName, ns),
 	}
 }
 

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -14,6 +14,8 @@ import (
 
 type MultusAnnotation struct {
 	Name string `json:"name"`
+	// Explicitly set the namespace so Multus resolves the NAD reliably across clusters
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // DefineDeployment returns deployment struct.
@@ -101,7 +103,10 @@ func RedefineWithMultus(deployment *appsv1.Deployment, nadNames []string) {
 	var nadAnnotations []MultusAnnotation
 
 	for _, nadName := range nadNames {
-		nadAnnotations = append(nadAnnotations, MultusAnnotation{Name: nadName})
+		nadAnnotations = append(nadAnnotations, MultusAnnotation{
+			Name:      nadName,
+			Namespace: deployment.Spec.Template.Namespace,
+		})
 	}
 
 	bString, _ := json.Marshal(nadAnnotations)

--- a/tests/utils/nad/nad.go
+++ b/tests/utils/nad/nad.go
@@ -2,6 +2,7 @@ package nad
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -10,15 +11,22 @@ import (
 
 // DefineNad returns basic network-attachment-definition manifest.
 func DefineNad(name string, namespace string) *netattdefv1.NetworkAttachmentDefinition {
+	// Optionally include a master interface for macvlan if provided via env
+	// This helps environments (e.g., microshift) where macvlan requires explicit master
+	master := os.Getenv("CERTSUITE_NAD_MASTER_IF")
+	baseCfg := fmt.Sprintf(`{"cniVersion": "0.4.0", "name": "%s", "type": "macvlan", "mode": "bridge"}`, name)
+	if master != "" {
+		// inject master right after the type/mode block
+		baseCfg = strings.TrimRight(baseCfg, "}") + fmt.Sprintf(", \"master\": \"%s\"}", master)
+	}
+
 	return &netattdefv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 		Spec: netattdefv1.NetworkAttachmentDefinitionSpec{
-			Config: fmt.Sprintf(
-				`{"cniVersion": "0.4.0", "name": "%s", "type": "macvlan", "mode": "bridge"}`,
-				name),
+			Config: baseCfg,
 		},
 	}
 }
@@ -27,8 +35,22 @@ func DefineNad(name string, namespace string) *netattdefv1.NetworkAttachmentDefi
 func RedefineNadWithWhereaboutsIpam(
 	nad *netattdefv1.NetworkAttachmentDefinition, network string) {
 	nad.Spec.Config = strings.Trim(nad.Spec.Config, `}`)
+	// Ensure master is present if provided via env and not already set
+	if !strings.Contains(nad.Spec.Config, `"master"`) {
+		if m := os.Getenv("CERTSUITE_NAD_MASTER_IF"); m != "" {
+			nad.Spec.Config = fmt.Sprintf(`%s, "master": "%s"`, nad.Spec.Config, m)
+		}
+	}
 	nad.Spec.Config = fmt.Sprintf(
 		"%s, %s}", nad.Spec.Config,
 		fmt.Sprintf(`"ipam":{ "type": "whereabouts", "range": "%s"}`, network),
 	)
+}
+
+// AddMasterToNad injects a macvlan master if not already present
+func AddMasterToNad(n *netattdefv1.NetworkAttachmentDefinition, master string) {
+	if master == "" || strings.Contains(n.Spec.Config, `"master"`) {
+		return
+	}
+	n.Spec.Config = strings.TrimRight(n.Spec.Config, "}") + fmt.Sprintf(`, "master": "%s"}`, master)
 }


### PR DESCRIPTION
The `UncertifiedContainerURLCnfTest` was using the older debug image which is roughly 500mb and they do similar things:

- Bash support: Includes /bin/bash which the deployment expects
- Command compatibility: Works with Command: []string{"/bin/bash", "-c", "sleep INF"}
- Reliability: Debian is stable and well-maintained
- Reproducible: Using specific version (12-slim) instead of latest