### PR TITLE
Ensure 'openshift-marketplace' namespace exists

### DIFF
--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -89,6 +89,10 @@ var _ = SynchronizedBeforeSuite(func() {
 	}
 
 	if !globalhelper.IsKindCluster() {
+		By("Ensure openshift-marketplace namespace exists")
+		err = globalhelper.CreateNamespace("openshift-marketplace")
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Create community-operators catalog source")
 		err = globalhelper.CreateCommunityOperatorsCatalogSource()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This pull request adds a step to ensure the `openshift-marketplace` namespace exists before creating the community-operators catalog source. This helps prevent errors if the namespace is missing in environments other than Kind.

Cluster setup improvements:

* Added logic to check for and create the `openshift-marketplace` namespace during test suite setup in `affiliated_certification_suite_test.go`, improving robustness for non-Kind clusters