### PR TITLE
Ensure 'openshift-marketplace' namespace exists

### DIFF
--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -89,6 +89,10 @@ var _ = SynchronizedBeforeSuite(func() {
 	}
 
 	if !globalhelper.IsKindCluster() {
+		By("Ensure openshift-marketplace namespace exists")
+		err = globalhelper.CreateNamespace("openshift-marketplace")
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Create community-operators catalog source")
 		err = globalhelper.CreateCommunityOperatorsCatalogSource()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This pull request adds a check to ensure that the `openshift-marketplace` namespace exists before creating the community-operators catalog source in the test setup. This helps prevent errors in environments where the namespace may not be present.

Test setup reliability:

* Added a step to create the `openshift-marketplace` namespace if it does not exist in the `SynchronizedBeforeSuite` setup in `affiliated_certification_suite_test.go`.