### PR TITLE
Disable image runs from nightlies

### DIFF
--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -19,11 +19,51 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  TEST_REPO: redhat-best-practices-for-k8s/certsuite
+
 jobs:
+  build-and-store-binary:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Clone the certsuite repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: ${{ env.TEST_REPO }}
+          path: certsuite
+          ref: main
+
+      - name: Extract dependent Pull Requests
+        uses: depends-on/depends-on-action@61cb3f4a0e2c8ae4b90c9448dc57c7ba9ca24c35 # main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          extra-dirs: certsuite
+
+      - name: Build the certsuite binary
+        run: make build-certsuite-tool
+        working-directory: certsuite
+
+      - name: Upload certsuite binary as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: certsuite-binary
+          path: certsuite/certsuite
+          retention-days: 1
   qe-ocp-testing:
     runs-on: ubuntu-24.04
+    needs: build-and-store-binary
     # Only run on PRs from the main repository, not from forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository && needs.build-and-store-binary.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -37,7 +77,6 @@ jobs:
       TEST_CERTSUITE_IMAGE_TAG: unstable
       DOCKER_CONFIG_DIR: '/home/runner/.docker/'
       SKIP_PRELOAD_IMAGES: true # Not needed for github-hosted runs
-      TEST_REPO: redhat-best-practices-for-k8s/certsuite
       # Enable infrastructure tolerations for better test reliability in CI environments
       ENABLE_INFRASTRUCTURE_TOLERATIONS: true
 
@@ -86,7 +125,6 @@ jobs:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
           waitForOperatorsReady: true
-          # crcMemory: 12000
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
 
@@ -103,13 +141,22 @@ jobs:
           path: certsuite
           ref: main
 
-      - name: Run the tests (against image)
+      - name: Download pre-built certsuite binary
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: certsuite-binary
+          path: certsuite/
+  
+      - name: Make binary executable
+        run: chmod +x certsuite/certsuite
+
+      - name: Run the tests (against binary)
         if: steps.check-secret.outputs.has-secret == 'true'
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 150
           max_attempts: 3
-          command: FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE}/certsuite CERTSUITE_IMAGE=${{env.TEST_CERTSUITE_IMAGE_NAME}} CERTSUITE_IMAGE_TAG=${{env.TEST_CERTSUITE_IMAGE_TAG}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true JOB_ID=${{github.run_id}} make test-features
+          command: FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE}/certsuite USE_BINARY=true DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true JOB_ID=${{github.run_id}} make test-features
 
       - name: Skip message for missing pull secret
         if: steps.check-secret.outputs.has-secret == 'false'


### PR DESCRIPTION
Disable image runs that run against `quick-ocp` as there seems to be some sort of upstream change in our actions runners that is limiting our memory now.