### PR TITLE
Remove grafana-operator from pull images check

### DIFF
--- a/.github/workflows/pull-images.yml
+++ b/.github/workflows/pull-images.yml
@@ -43,6 +43,5 @@ jobs:
           podman pull --authfile /home/runner/pull-secret.txt registry.redhat.io/openshift4/dpdk-base-rhel8:v4.9
           podman pull --authfile /home/runner/pull-secret.txt registry.connect.redhat.com/cockroachdb/cockroach:v23.1.17
           podman pull --authfile /home/runner/pull-secret.txt registry.access.redhat.com/ubi8/nodejs-12:latest
-          podman pull --authfile /home/runner/pull-secret.txt quay.io/grafana/grafana-operator:v5.18.0
           podman pull --authfile /home/runner/pull-secret.txt registry.connect.redhat.com/anchore/engine-operator-bundle@sha256:fbbe7e6c1d75c4de2f47e2c825c930568e85f1134545e9d890a0c9f3d9187a4d
           podman pull --authfile /home/runner/pull-secret.txt registry.redhat.io/quay/quay-operator-rhel8@sha256:59c6daa886c01039cb96da04ae250e0e9b89c73dbd7ece934cf8bf9e9f529812


### PR DESCRIPTION
https://github.com/redhat-best-practices-for-k8s/certsuite-qe/actions/runs/17197096642/job/48780791006

For some reason, this org/repo in quay does not *exist* anymore.