### PR TITLE
Prebuild image for QE PR runs

### DIFF
--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -23,6 +23,39 @@ env:
   TEST_REPO: redhat-best-practices-for-k8s/certsuite
 
 jobs:
+  build-and-store-image:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Check out certsuite code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: ${{ env.TEST_REPO }}
+          path: certsuite
+          ref: main
+
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build temporary image tag for this PR
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ./certsuite
+          file: ./certsuite/Dockerfile
+          tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest
+          outputs: type=docker,dest=/tmp/testimage.tar
+
+      - name: Store image as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: testimage
+          path: /tmp/testimage.tar
+
+  # Build and store the certsuite binary
   build-and-store-binary:
     runs-on: ubuntu-24.04
     steps:
@@ -61,8 +94,8 @@ jobs:
           retention-days: 1
 
   qe-testing:
-    needs: build-and-store-binary
-    if: ${{ needs.build-and-store-binary.result == 'success' }}
+    needs: [build-and-store-binary, build-and-store-image]
+    if: ${{ needs.build-and-store-binary.result == 'success' && needs.build-and-store-image.result == 'success' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -73,7 +106,7 @@ jobs:
       KUBECONFIG: '/home/runner/.kube/config'
       PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
       TEST_CERTSUITE_IMAGE_NAME: quay.io/redhat-best-practices-for-k8s/certsuite
-      TEST_CERTSUITE_IMAGE_TAG: unstable
+      TEST_CERTSUITE_IMAGE_TAG: localtest
       DOCKER_CONFIG_DIR: '/home/runner/.docker/'
       SKIP_PRELOAD_IMAGES: true # Not needed for github-hosted runs
 
@@ -151,6 +184,15 @@ jobs:
 
       - name: Make binary executable
         run: chmod +x certsuite/certsuite
+
+      - name: Download pre-built image
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: testimage
+          path: /tmp
+
+      - name: Load the image
+        run: docker load -i /tmp/testimage.tar
 
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2


### PR DESCRIPTION
Based on changes from #1189 this adds a prebuild step to built the `certsuite` localtest image from scratch.