### PR TITLE
Remove dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,17 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      dev-dependencies:
-        dependency-type: "development"
-      prod-dependencies:
-        dependency-type: "production"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      dev-dependencies:
-        dependency-type: "development"
-      prod-dependencies:
-        dependency-type: "production"


### PR DESCRIPTION
This pull request makes a small change to the Dependabot configuration by removing the grouping of dependencies in the `.github/dependabot.yml` file. This simplifies the configuration and will result in Dependabot opening separate PRs for each dependency update rather than grouping them.