### PR TITLE
Test custom probe name flag

### DIFF
--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   TEST_REPO: redhat-best-practices-for-k8s/certsuite
+  TEST_REPO_BRANCH: add_daemonset_label
   ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
@@ -42,7 +43,7 @@ jobs:
         with:
           repository: ${{ env.TEST_REPO }}
           path: certsuite
-          ref: main
+          ref: ${{ env.TEST_REPO_BRANCH }}
 
       - name: Extract dependent Pull Requests
         uses: depends-on/depends-on-action@61cb3f4a0e2c8ae4b90c9448dc57c7ba9ca24c35 # main
@@ -140,7 +141,7 @@ jobs:
         with:
           repository: ${{ env.TEST_REPO }}
           path: certsuite
-          ref: main
+          ref: ${{ env.TEST_REPO_BRANCH }}
 
       - name: Download pre-built certsuite binary
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   TEST_REPO: redhat-best-practices-for-k8s/certsuite
+  TEST_REPO_BRANCH: add_daemonset_label
 
 jobs:
   build-and-store-image:
@@ -36,7 +37,7 @@ jobs:
         with:
           repository: ${{ env.TEST_REPO }}
           path: certsuite
-          ref: main
+          ref: ${{ env.TEST_REPO_BRANCH }}
 
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -74,7 +75,7 @@ jobs:
         with:
           repository: ${{ env.TEST_REPO }}
           path: certsuite
-          ref: main
+          ref: ${{ env.TEST_REPO_BRANCH }}
 
       - name: Extract dependent Pull Requests
         uses: depends-on/depends-on-action@61cb3f4a0e2c8ae4b90c9448dc57c7ba9ca24c35 # main
@@ -168,7 +169,7 @@ jobs:
         with:
           repository: ${{ env.TEST_REPO }}
           path: certsuite
-          ref: main
+          ref: ${{ env.TEST_REPO_BRANCH }}
 
       - name: Extract dependent Pull Requests
         uses: depends-on/depends-on-action@61cb3f4a0e2c8ae4b90c9448dc57c7ba9ca24c35 # main

--- a/tests/globalhelper/rbac.go
+++ b/tests/globalhelper/rbac.go
@@ -245,10 +245,8 @@ func createAndWaitUntilPVCIsBound(client corev1Typed.CoreV1Interface, pvc *corev
 	}
 
 	Eventually(func() bool {
-
 		status, err := isPvcBound(client, pvc.Name, pvc.Namespace, pvName)
 		if err != nil {
-
 			klog.V(5).Info(fmt.Sprintf(
 				"pvc %s is not bound, retry in %d seconds", pvc.Name, retryInterval))
 

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -112,6 +112,7 @@ func launchTestsViaBinary(testCaseName string, tcNameForReport string, reportDir
 		"--output-dir", reportDir,
 		"--label-filter", testCaseName,
 		"--sanitize-claim", "true",
+		"--unique-probe-name", "true",
 	}
 
 	cmdPath := fmt.Sprintf("%s/%s", GetConfiguration().General.CertsuiteRepoPath,
@@ -188,6 +189,7 @@ func launchTestsViaImage(testCaseName string, tcNameForReport string, reportDir 
 		"--enable-data-collection", "false",
 		"--sanitize-claim", "true",
 		"--label-filter", testCaseName,
+		"--unique-probe-name", "true",
 	}
 
 	// print the command


### PR DESCRIPTION
Testing out new parallel processing flag to help us from stepping on parallel toes.

**Workflow configuration updates:**

* Both `.github/workflows/qe.yml` and `.github/workflows/qe-ocp.yml` now use a new environment variable `TEST_REPO_BRANCH` (set to `add_daemonset_label`) to specify which branch of the `certsuite` repository to check out, instead of hardcoding `main`. All relevant `actions/checkout` steps have been updated to use this variable. [[1]](diffhunk://#diff-a90bd711e6964ed07f1bd5524ede4bbbdc4a51f8baab54f295f8ec3fbccb8cbdR24) [[2]](diffhunk://#diff-a90bd711e6964ed07f1bd5524ede4bbbdc4a51f8baab54f295f8ec3fbccb8cbdL39-R40) [[3]](diffhunk://#diff-a90bd711e6964ed07f1bd5524ede4bbbdc4a51f8baab54f295f8ec3fbccb8cbdL77-R78) [[4]](diffhunk://#diff-a90bd711e6964ed07f1bd5524ede4bbbdc4a51f8baab54f295f8ec3fbccb8cbdL171-R172) [[5]](diffhunk://#diff-c13b14c9b655fb5672a795fc5e1c27be6d66587dfa15f814f0ccf78e4a50277fR24) [[6]](diffhunk://#diff-c13b14c9b655fb5672a795fc5e1c27be6d66587dfa15f814f0ccf78e4a50277fL45-R46) [[7]](diffhunk://#diff-c13b14c9b655fb5672a795fc5e1c27be6d66587dfa15f814f0ccf78e4a50277fL143-R144)

**Test runner improvements:**

* The `launchTestsViaBinary` and `launchTestsViaImage` functions in `tests/globalhelper/runhelper.go` now include the `--unique-probe-name true` flag when launching tests, enabling the new certsuite feature for unique probe names. [[1]](diffhunk://#diff-0ec231a3e6d3ab7f3851f21fe02a017d9f3c12a7f97ba7c2f86395846c108240R115) [[2]](diffhunk://#diff-0ec231a3e6d3ab7f3851f21fe02a017d9f3c12a7f97ba7c2f86395846c108240R192)