### PR TITLE
Fix linter

### DIFF
--- a/tests/globalhelper/rbac.go
+++ b/tests/globalhelper/rbac.go
@@ -245,10 +245,8 @@ func createAndWaitUntilPVCIsBound(client corev1Typed.CoreV1Interface, pvc *corev
 	}
 
 	Eventually(func() bool {
-
 		status, err := isPvcBound(client, pvc.Name, pvc.Namespace, pvName)
 		if err != nil {
-
 			klog.V(5).Info(fmt.Sprintf(
 				"pvc %s is not bound, retry in %d seconds", pvc.Name, retryInterval))
 


### PR DESCRIPTION
This pull request makes a minor change to the `createAndWaitUntilPVCIsBound` function in `tests/globalhelper/rbac.go`, specifically removing some unnecessary blank lines to clean up the code formatting.