### PR TITLE
fix: detect environment to determine expected certsuite outcomes

### DIFF
--- a/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
+++ b/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
@@ -78,17 +78,20 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", Label("
 			Expect(cs.Ready).To(BeTrue(), fmt.Sprintf("Container %s should be ready", cs.Name))
 		}
 
-		// Check if PerformanceProfiles are configured - this affects scheduling policy
-		hasPerformanceProfiles, _ := globalhelper.HasPerformanceProfiles()
-		GinkgoWriter.Printf("Cluster has PerformanceProfiles: %v\n", hasPerformanceProfiles)
+		By("Detect scheduling policy on the test pod to determine expected certsuite outcome")
+		// If PID 1 uses SCHED_FIFO or SCHED_RR, RT scheduling is active and certsuite
+		// will return FAILED. If SCHED_OTHER/SCHED_BATCH/SCHED_IDLE, certsuite should PASS.
+		chrtOutput, chrtErr := globalhelper.ExecCommand(*runningPod, []string{"chrt", "-p", "1"})
+		Expect(chrtErr).ToNot(HaveOccurred(), "chrt -p 1 must succeed to determine expected certsuite outcome")
 
-		// Determine expected result based on cluster configuration
-		// If PerformanceProfiles exist, containers may have RT scheduling policies
-		// causing the test to FAIL instead of PASS
+		chrtStr := chrtOutput.String()
+		GinkgoWriter.Printf("chrt -p 1 output: %s\n", chrtStr)
+
 		expectedResult := globalparameters.TestCasePassed
 
-		if hasPerformanceProfiles {
-			GinkgoWriter.Printf("Cluster has PerformanceProfiles - test may FAIL due to RT scheduling\n")
+		if strings.Contains(chrtStr, "SCHED_FIFO") || strings.Contains(chrtStr, "SCHED_RR") {
+			GinkgoWriter.Printf("RT scheduling detected on PID 1 — expecting certsuite to return FAILED\n")
+			expectedResult = globalparameters.TestCaseFailed
 		}
 
 		By("Start shared-cpu-pool-non-rt-scheduling-policy test")
@@ -98,17 +101,9 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", Label("
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify test case status in Claim report")
-		// Accept PASSED (expected for non-RT clusters), FAILED (when RT scheduling is enabled),
-		// or SKIPPED (when certsuite decides to skip for internal reasons)
-		acceptedStatuses := []string{expectedResult, globalparameters.TestCaseSkipped}
-		if hasPerformanceProfiles {
-			// On clusters with PerformanceProfiles, RT scheduling may be enabled
-			// causing containers to have RT scheduling policies
-			acceptedStatuses = append(acceptedStatuses, globalparameters.TestCaseFailed)
-		}
-		err = globalhelper.ValidateIfReportsAreValidWithAcceptedStatuses(
+		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.CertsuiteSharedCPUPoolSchedulingPolicy,
-			acceptedStatuses, randomReportDir)
+			expectedResult, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify CheckDetails report completeness")

--- a/tests/platformalteration/tests/platform_alteration_ocp_lifecycle.go
+++ b/tests/platformalteration/tests/platform_alteration_ocp_lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,12 +60,26 @@ var _ = Describe("platform-alteration-ocp-lifecycle", Label("platformalteration4
 		err := verifyRHCOSVersionsInCertsuite()
 		Expect(err).ToNot(HaveOccurred(), "RHCOS version validation failed")
 
+		By("Determine expected certsuite outcome from OCP lifecycle status")
+		ocpVersion, vErr := globalhelper.GetClusterVersion()
+		Expect(vErr).ToNot(HaveOccurred(), "Failed to get OCP cluster version")
+
+		isEOL := isOCPEndOfLife(ocpVersion)
+		GinkgoWriter.Printf("OCP version %s end-of-life: %v\n", ocpVersion, isEOL)
+
+		expectedResult := globalparameters.TestCasePassed
+
+		if isEOL {
+			GinkgoWriter.Printf("OCP %s is past end-of-life — expecting certsuite to return FAILED\n", ocpVersion)
+			expectedResult = globalparameters.TestCaseFailed
+		}
+
 		By("Start platform-alteration-ocp-lifecycle test")
 		err = globalhelper.LaunchTests(tsparams.CertsuiteOCPLifecycleName,
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomCertsuiteConfigDir)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = globalhelper.ValidateIfReportsAreValid(tsparams.CertsuiteOCPLifecycleName, globalparameters.TestCasePassed, randomReportDir)
+		err = globalhelper.ValidateIfReportsAreValid(tsparams.CertsuiteOCPLifecycleName, expectedResult, randomReportDir)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })
@@ -146,4 +161,34 @@ func verifyRHCOSVersions(nodes []corev1.Node, rhcosVersionMapContent string) err
 	}
 
 	return nil
+}
+
+// Kept in sync with certsuite's pkg/compatibility/compatibility.go.
+var ocpMaintenanceSupportEndDates = map[string]time.Time{
+	"4.12": time.Date(2026, 1, 17, 0, 0, 0, 0, time.UTC),
+	"4.13": time.Date(2024, 11, 17, 0, 0, 0, 0, time.UTC),
+	"4.14": time.Date(2026, 10, 31, 0, 0, 0, 0, time.UTC),
+	"4.15": time.Date(2025, 8, 27, 0, 0, 0, 0, time.UTC),
+	"4.16": time.Date(2027, 6, 27, 0, 0, 0, 0, time.UTC),
+	"4.17": time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	"4.18": time.Date(2028, 2, 25, 0, 0, 0, 0, time.UTC),
+	"4.19": time.Date(2026, 12, 17, 0, 0, 0, 0, time.UTC),
+	"4.20": time.Date(2028, 10, 21, 0, 0, 0, 0, time.UTC),
+	"4.21": time.Date(2027, 8, 3, 0, 0, 0, 0, time.UTC),
+}
+
+func isOCPEndOfLife(version string) bool {
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return false
+	}
+
+	majorMinor := parts[0] + "." + parts[1]
+
+	mseDate, ok := ocpMaintenanceSupportEndDates[majorMinor]
+	if !ok {
+		return false
+	}
+
+	return !time.Now().Before(mseDate)
 }


### PR DESCRIPTION
## Summary

- Detect actual RT scheduling policy on test pods to predict certsuite outcome for shared-cpu-pool tests
- Check OCP lifecycle dates to predict certsuite outcome for OCP lifecycle tests

## Problem

Two tests were failing because they assumed a specific certsuite outcome without checking the environment:

**`shared-cpu-pool-non-rt-scheduling-policy`** (OCP 4.14, 4.16):
Only accepted `[passed skipped]` on clusters without PerformanceProfiles. But RT scheduling can be enabled through other mechanisms (Node Tuning Operator, tuned profiles, kernel config), causing certsuite to legitimately return `failed`.

**`platform-alteration-ocp-lifecycle`** (OCP 4.17):
Only accepted `passed`, but certsuite returns `failed` for OCP versions past end-of-life. OCP 4.17 reached EOL on April 1, 2026.

## Fix

**Scheduling policy test**: Before launching certsuite, runs `chrt -p 1` on the test pod to detect the actual scheduling policy. If `SCHED_FIFO` or `SCHED_RR` is detected, expects certsuite to return `failed`. Otherwise expects `passed`. Fails the test if `chrt` itself cannot determine the scheduling policy.

**OCP lifecycle test**: Checks the cluster's OCP version against maintenance support end dates (mirrored from certsuite's compatibility package). If the version is past EOL, expects `failed`. Otherwise expects `passed`.

## Test plan

- [ ] OCP 4.14 non-intrusive nightly: performance-ocp suite should pass
- [ ] OCP 4.16 non-intrusive nightly: performance-ocp suite should pass
- [ ] OCP 4.17 non-intrusive nightly: platformalteration4-ocp suite should pass