### PR TITLE
Add retry loop for catalog source creation on transient failures

### DIFF
--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -104,16 +104,8 @@ var _ = SynchronizedBeforeSuite(func() {
 		err = globalhelper.CreateNamespace("openshift-marketplace")
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Create community-operators catalog source")
-		err = globalhelper.CreateCommunityOperatorsCatalogSource()
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Create certified-operators catalog source")
-		err = globalhelper.DeployRHCertifiedOperatorSource("")
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Check if catalog sources are available")
-		err = globalhelper.ValidateCatalogSources()
+		By("Create catalog sources and wait for them to become ready")
+		err = globalhelper.CreateAndValidateCatalogSources(false)
 		Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")
 	}
 }, func() {})

--- a/tests/globalhelper/catalogsources.go
+++ b/tests/globalhelper/catalogsources.go
@@ -81,6 +81,58 @@ func validateCatalogSources(opclient v1alpha1typed.OperatorsV1alpha1Interface) e
 	return fmt.Errorf("timed out after %s waiting for catalog sources %v to be READY", timeout, requiredCatalogSources)
 }
 
+func deleteCatalogSourceByName(name string) error {
+	err := GetAPIClient().OperatorsV1alpha1Interface.CatalogSources(CatalogSourceNamespace).Delete(
+		context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete catalog source %s: %w", name, err)
+	}
+
+	return nil
+}
+
+func CreateAndValidateCatalogSources(includeRedHat bool) error {
+	const maxAttempts = 3
+
+	sources := map[string]func() error{
+		"community-operators": CreateCommunityOperatorsCatalogSource,
+		"certified-operators": func() error { return DeployRHCertifiedOperatorSource("") },
+	}
+
+	if includeRedHat {
+		sources["redhat-operators"] = func() error { return DeployRHOperatorSource("") }
+	}
+
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		for name, create := range sources {
+			if err := create(); err != nil {
+				return fmt.Errorf("failed to create catalog source %s: %w", name, err)
+			}
+		}
+
+		lastErr = ValidateCatalogSources()
+		if lastErr == nil {
+			return nil
+		}
+
+		klog.Infof("Catalog source validation failed (attempt %d/%d): %v", attempt, maxAttempts, lastErr)
+
+		if attempt == maxAttempts {
+			break
+		}
+
+		for name := range sources {
+			if delErr := deleteCatalogSourceByName(name); delErr != nil {
+				klog.Infof("Warning: failed to delete catalog source %s: %v", name, delErr)
+			}
+		}
+	}
+
+	return fmt.Errorf("catalog sources not ready after %d attempts: %w", maxAttempts, lastErr)
+}
+
 func createCatalogSource(name, url string) error {
 	return createCatalogSourceWithClient(GetAPIClient().OperatorsV1alpha1Interface, name, url)
 }

--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -32,20 +32,8 @@ var _ = SynchronizedBeforeSuite(func() {
 
 	// Safeguard against running the operator tests on a cluster without catalog sources
 	if !globalhelper.IsKindCluster() {
-		By("Create community-operators catalog source")
-		err := globalhelper.CreateCommunityOperatorsCatalogSource()
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Create certified-operators catalog source")
-		err = globalhelper.DeployRHCertifiedOperatorSource("")
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Create redhat-operators catalog source")
-		err = globalhelper.DeployRHOperatorSource("")
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Check if catalog sources are available")
-		err = globalhelper.ValidateCatalogSources()
+		By("Create catalog sources and wait for them to become ready")
+		err := globalhelper.CreateAndValidateCatalogSources(true)
 		Expect(err).ToNot(HaveOccurred(), "All necessary catalog sources are not available")
 	}
 }, func() {})


### PR DESCRIPTION
## Summary
- Catalog sources on resource-constrained CRC clusters sometimes get stuck in `TRANSIENT_FAILURE` state during nightly CI, causing `affiliatedcertification` and `operator` suite `BeforeSuite` to time out and skip all tests
- Adds a retry loop (up to 3 attempts) that deletes and recreates catalog sources when validation fails, giving the cluster another chance to stabilize
- Both `affiliatedcertification` and `operator` suites now use the shared `CreateAndValidateCatalogSources` / `CreateAndValidateAllCatalogSources` helpers

## Test plan
- [ ] Verify lint passes (`make lint`)
- [ ] Verify unit tests pass (`make test`)
- [ ] Monitor nightly CI runs for `affiliatedcertification-ocp` and `operator-ocp` jobs on OCP 4.18/4.20