### PR TITLE
Add sigs.k8s.io/* to dependabot k8s dependency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       k8s-io:
         patterns:
           - "k8s.io/*"
+          - "sigs.k8s.io/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Adds `sigs.k8s.io/*` to the `k8s-io` dependabot group alongside `k8s.io/*`
- Ensures controller-runtime and other sigs.k8s.io dependencies update together with k8s.io packages, preventing version mismatch build failures

## Related PRs
- https://github.com/sebrandon1/imagecertinfo-operator/pull/103
- https://github.com/sebrandon1/tls-compliance-operator/pull/109
- https://github.com/redhat-best-practices-for-k8s/checks-qe/pull/29