### PR TITLE
fix: log CheckDetails before status assertion for scheduling policy tests

### DIFF
--- a/tests/globalhelper/checkdetails.go
+++ b/tests/globalhelper/checkdetails.go
@@ -3,6 +3,8 @@ package globalhelper
 import (
 	"encoding/json"
 	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
 )
 
 // ReportObject mirrors the certsuite's testhelper.ReportObject structure.
@@ -53,6 +55,27 @@ func GetTestCaseCheckDetails(tcName, reportDir string) (*CheckDetails, error) {
 	}
 
 	return details, nil
+}
+
+// LogCheckDetails writes CheckDetails summary and per-object reasons to GinkgoWriter.
+// Safe to call when checkDetailsErr is non-nil (logs nothing).
+func LogCheckDetails(checkDetails *CheckDetails, checkDetailsErr error) {
+	if checkDetailsErr != nil {
+		return
+	}
+
+	GinkgoWriter.Printf("CheckDetails: %d compliant, %d non-compliant objects\n",
+		len(checkDetails.CompliantObjectsOut), len(checkDetails.NonCompliantObjectsOut))
+
+	for i, obj := range checkDetails.CompliantObjectsOut {
+		GinkgoWriter.Printf("Compliant[%d]: type=%s reason=%s\n",
+			i, obj.ObjectType, GetReportObjectFieldValue(obj, "Reason"))
+	}
+
+	for i, obj := range checkDetails.NonCompliantObjectsOut {
+		GinkgoWriter.Printf("NonCompliant[%d]: type=%s reason=%s\n",
+			i, obj.ObjectType, GetReportObjectFieldValue(obj, "Reason"))
+	}
 }
 
 // GetReportObjectFieldValue returns the value for a given key from a ReportObject's parallel arrays.

--- a/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
+++ b/tests/performance/tests/shared-cpu-pool-non-rt-scheduling-policy.go
@@ -101,6 +101,12 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", Label("
 			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomCertsuiteConfigDir)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Inspect CheckDetails from Claim report for diagnostics")
+
+		checkDetails, checkDetailsErr := globalhelper.GetTestCaseCheckDetails(
+			tsparams.CertsuiteSharedCPUPoolSchedulingPolicy, randomReportDir)
+		globalhelper.LogCheckDetails(checkDetails, checkDetailsErr)
+
 		By("Verify test case status in Claim report")
 		err = globalhelper.ValidateIfReportsAreValid(
 			tsparams.CertsuiteSharedCPUPoolSchedulingPolicy,
@@ -108,24 +114,14 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", Label("
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify CheckDetails report completeness")
-		checkDetails, err := globalhelper.GetTestCaseCheckDetails(
-			tsparams.CertsuiteSharedCPUPoolSchedulingPolicy, randomReportDir)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(checkDetailsErr).ToNot(HaveOccurred())
 
 		totalObjects := len(checkDetails.CompliantObjectsOut) + len(checkDetails.NonCompliantObjectsOut)
-		GinkgoWriter.Printf("CheckDetails: %d compliant, %d non-compliant objects\n",
-			len(checkDetails.CompliantObjectsOut), len(checkDetails.NonCompliantObjectsOut))
 		Expect(totalObjects).To(BeNumerically(">=", 1),
 			"At least one report object expected (no early abort)")
 
-		for i, obj := range checkDetails.CompliantObjectsOut {
-			GinkgoWriter.Printf("Compliant[%d]: type=%s reason=%s\n",
-				i, obj.ObjectType, globalhelper.GetReportObjectFieldValue(obj, "Reason"))
-		}
-
-		for i, obj := range checkDetails.NonCompliantObjectsOut {
+		for _, obj := range checkDetails.NonCompliantObjectsOut {
 			reason := globalhelper.GetReportObjectFieldValue(obj, "Reason")
-			GinkgoWriter.Printf("NonCompliant[%d]: type=%s reason=%s\n", i, obj.ObjectType, reason)
 			Expect(reason).ToNot(ContainSubstring("could not determine scheduling policy"),
 				"Unhandled scheduling policy error found in non-compliant objects")
 		}
@@ -169,6 +165,12 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", Label("
 			randomReportDir, randomCertsuiteConfigDir)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Inspect CheckDetails from Claim report for diagnostics")
+
+		checkDetails, checkDetailsErr := globalhelper.GetTestCaseCheckDetails(
+			tsparams.CertsuiteSharedCPUPoolSchedulingPolicy, randomReportDir)
+		globalhelper.LogCheckDetails(checkDetails, checkDetailsErr)
+
 		By("Verify test case completed (any terminal status accepted)")
 		err = globalhelper.ValidateIfReportsAreValidWithAcceptedStatuses(
 			tsparams.CertsuiteSharedCPUPoolSchedulingPolicy,
@@ -177,17 +179,12 @@ var _ = Describe("performance-shared-cpu-pool-non-rt-scheduling-policy", Label("
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify CheckDetails for process disappearance handling")
-		checkDetails, err := globalhelper.GetTestCaseCheckDetails(
-			tsparams.CertsuiteSharedCPUPoolSchedulingPolicy, randomReportDir)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(checkDetailsErr).ToNot(HaveOccurred())
 
 		totalObjects := len(checkDetails.CompliantObjectsOut) + len(checkDetails.NonCompliantObjectsOut)
-		GinkgoWriter.Printf("CheckDetails: %d compliant, %d non-compliant objects\n",
-			len(checkDetails.CompliantObjectsOut), len(checkDetails.NonCompliantObjectsOut))
 		Expect(totalObjects).To(BeNumerically(">=", 1),
 			"At least one report object expected (no early abort)")
 
-		// Verify that any "process disappeared" entries are in the compliant list, never non-compliant
 		disappearedCount := 0
 
 		for _, obj := range checkDetails.CompliantObjectsOut {


### PR DESCRIPTION
## Summary

- Move CheckDetails diagnostic logging **before** the status assertion in `shared-cpu-pool-non-rt-scheduling-policy` tests so non-compliant object reasons appear in CI output even when the test fails
- Extract the common diagnostic logging into a reusable `LogCheckDetails` helper in `globalhelper/checkdetails.go`

## Problem

The `performance-shared-cpu-pool-non-rt-scheduling-policy` / "One pod with container running in shared cpu pool" test has been intermittently failing on the OCP 4.14 nightly CI (~50% of runs). The certsuite reports the test as FAILED when it should PASS, but we can't determine why because the CheckDetails diagnostic logging was gated behind the assertion that fails — making the root cause invisible in CI logs.

## Root Cause Analysis

The QE test correctly detects `SCHED_OTHER` / priority 0 (non-RT) and expects certsuite to PASS. But certsuite's scheduling check (`ProcessPidsCPUScheduling`) can fail for several transient reasons:
1. `chrt -p <pid>` exec fails from probe pod (transient API error)
2. `chrt` produces unexpected stderr
3. Process PID reused between `ps` scan and `chrt` check

The CheckDetails in the claim file would reveal which of these is happening, but the old code read them **after** the assertion that fails — so they were never printed.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (pre-existing unrelated `TestDebugCertsuite` failure on macOS)
- [x] Next CI run will show the actual certsuite failure reason, informing whether a certsuite-side fix is needed