### PR TITLE
ci: remove depends-on-action from workflows

### DIFF
--- a/.github/workflows/qe-ocp.yml
+++ b/.github/workflows/qe-ocp.yml
@@ -47,12 +47,6 @@ jobs:
           path: certsuite
           ref: ${{ env.CERTSUITE_REF }}
 
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          extra-dirs: certsuite
-
       - name: Build the certsuite binary
         run: make build-certsuite-tool
         working-directory: certsuite

--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -79,12 +79,6 @@ jobs:
           path: certsuite
           ref: ${{ env.CERTSUITE_REF }}
 
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          extra-dirs: certsuite
-
       - name: Build the certsuite binary
         run: make build-certsuite-tool
         working-directory: certsuite
@@ -234,12 +228,6 @@ jobs:
           path: certsuite
           ref: ${{ env.CERTSUITE_REF }}
 
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          extra-dirs: certsuite-sample-workload certsuite
-
       - name: Download pre-built certsuite binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -272,15 +260,5 @@ jobs:
           timeout_minutes: 150
           max_attempts: 3
           command: FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE}/certsuite USE_BINARY=true DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true JOB_ID=${{github.run_id}} make test-features
-
-  check-all-dependencies-are-merged:
-    runs-on: ubuntu-24.04
-    steps:
-
-      - name: Extract dependent PR
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          check-unmerged-pr: true
 
 ...


### PR DESCRIPTION
## Summary

- Remove 3 `depends-on/depends-on-action` steps from `qe.yml` and `qe-ocp.yml`
- Remove the `check-all-dependencies-are-merged` job from `qe.yml` that existed solely for this action

## Why

The `depends-on/depends-on-action` uses Node.js 20, which GitHub [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and began forcing to Node.js 24 on June 16, 2026. This causes the action to fail with HTTP 500 errors, breaking CI on every PR.

The action has an [open issue (#69)](https://github.com/depends-on/depends-on-action/issues/69) to upgrade, but no fix has been released.

Jira: [CNFCERT-1424](https://redhat.atlassian.net/browse/CNFCERT-1424)

## Related PRs

- [certsuite#3731](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3731)
- [certsuite-operator#317](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/pull/317)
- [certsuite-operator-plugin#12](https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin/pull/12)
- [collector#705](https://github.com/redhat-best-practices-for-k8s/collector/pull/705)