### PR TITLE
fix: use restrictive directory permissions instead of 0777

### DIFF
--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 	testclient "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/utils/client"
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/utils/config"
 	"k8s.io/client-go/kubernetes"
@@ -70,14 +71,14 @@ func GenerateDirectories(randomStr string) (reportDir, configDir string) {
 	reportDir = GetConfiguration().General.CertsuiteReportDir + "/" + randomStr
 	configDir = GetConfiguration().General.CertsuiteConfigDir + "/" + randomStr
 
-	err := os.MkdirAll(reportDir, os.ModePerm)
+	err := os.MkdirAll(reportDir, globalparameters.DirPermissions)
 	if err != nil {
 		klog.ErrorS(err, "could not create dest directory", "dir", reportDir)
 	}
 
-	err = os.MkdirAll(configDir, os.ModePerm)
+	err = os.MkdirAll(configDir, globalparameters.DirPermissions)
 	if err != nil {
-		klog.ErrorS(err, "could not create dest directory", "dir", reportDir)
+		klog.ErrorS(err, "could not create dest directory", "dir", configDir)
 	}
 
 	return reportDir, configDir

--- a/tests/globalhelper/reporthelper.go
+++ b/tests/globalhelper/reporthelper.go
@@ -184,7 +184,7 @@ func CopyClaimFileToTcFolder(tcName, formattedTcName, reportDir string) {
 	}
 
 	// create destination folder
-	err = os.MkdirAll(dstDir, os.ModePerm)
+	err = os.MkdirAll(dstDir, globalparameters.DirPermissions)
 	if err != nil {
 		klog.ErrorS(err, "could not create dest directory", "dir", dstDir)
 	}

--- a/tests/globalparameters/globalparameters.go
+++ b/tests/globalparameters/globalparameters.go
@@ -1,6 +1,13 @@
 package globalparameters
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"io/fs"
+)
+
+const (
+	DirPermissions fs.FileMode = 0750
+)
 
 type (
 	CertsuiteConfig struct {

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 	testclient "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/utils/client"
 
 	"github.com/kelseyhightower/envconfig"
@@ -121,7 +122,7 @@ func (c *Config) DebugCertsuite() (bool, error) {
 func (c *Config) CreateLogFile(testSuite string, tcName string) *os.File {
 	folderPath := filepath.Join(c.General.ReportDirAbsPath, "Debug", testSuite, tcName)
 
-	err := os.MkdirAll(folderPath, 0755)
+	err := os.MkdirAll(folderPath, globalparameters.DirPermissions)
 	if err != nil && !os.IsExist(err) {
 		// we only panic in case the error is different than "folder already exists".
 		panic(err)
@@ -230,7 +231,7 @@ func deployCertsuiteDir(confFileName string, dirName string, yamlTag string, env
 
 	klog.V(4).Info(fmt.Sprintf("%s directory is not present. Creating directory", dirName))
 
-	err = os.MkdirAll(dirName, 0777)
+	err = os.MkdirAll(dirName, globalparameters.DirPermissions)
 	if err != nil {
 		return fmt.Errorf("failed to create dir %v: %w", dirName, err)
 	}
@@ -241,7 +242,7 @@ func deployCertsuiteDir(confFileName string, dirName string, yamlTag string, env
 func (c *Config) makeDockerConfig() error {
 	var configFile *os.File
 
-	err := os.MkdirAll(c.General.DockerConfigDir, 0777)
+	err := os.MkdirAll(c.General.DockerConfigDir, globalparameters.DirPermissions)
 	if err != nil {
 		return fmt.Errorf("failed to create dir %v: %w", c.General.DockerConfigDir, err)
 	}


### PR DESCRIPTION
## Summary

- Replace overly permissive `0777` and `os.ModePerm` with a shared `globalparameters.DirPermissions` constant (`0750`) for all directory creation
- Fix pre-existing logging bug in `init.go` where `configDir` creation errors incorrectly logged `reportDir`
- Fix missed `0755` in `config.go` `CreateLogFile` for consistency

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes (pre-existing test failure in `TestDebugCertsuite` is unrelated)
- [ ] Verify directory creation still works in integration tests