### PR TITLE
refactor: extract suite setup boilerplate into globalhelper.RunSuite

### DIFF
--- a/tests/accesscontrol/access_control_suite_test.go
+++ b/tests/accesscontrol/access_control_suite_test.go
@@ -3,27 +3,17 @@
 package accesscontrol
 
 import (
-	"flag"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"runtime"
-	"testing"
 
 	_ "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/accesscontrol/tests"
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
 )
 
 func TestAccessControl(t *testing.T) {
-	_, currentFile, _, _ := runtime.Caller(0)
-	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
-	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
-
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CNFCert access-control tests", reporterConfig)
+	globalhelper.RunSuite(t, "CNFCert access-control tests")
 }
 
 var _ = SynchronizedBeforeSuite(func() {

--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -3,11 +3,9 @@
 package affiliatedcertification
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -22,14 +20,7 @@ import (
 )
 
 func TestAffiliatedCertification(t *testing.T) {
-	_, currentFile, _, _ := runtime.Caller(0)
-	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
-	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
-
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CNFCert affiliated-certification tests", reporterConfig)
+	globalhelper.RunSuite(t, "CNFCert affiliated-certification tests")
 }
 
 var (

--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -1,8 +1,11 @@
 package globalhelper
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"runtime"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -112,6 +115,21 @@ func BeforeEachSetupWithRandomPrivilegedNamespace(incomingNamespace string) (ran
 	randomReportDir, randomConfigDir = GenerateDirectories(randomNamespace)
 
 	return randomNamespace, randomReportDir, randomConfigDir
+}
+
+func RunSuite(t *testing.T, suiteName string) {
+	t.Helper()
+
+	_, callerFile, _, _ := runtime.Caller(1)
+
+	_ = flag.Lookup("logtostderr").Value.Set("true")
+	_ = flag.Lookup("v").Value.Set(GetConfiguration().General.VerificationLogLevel)
+
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = GetConfiguration().GetReportPath(callerFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, suiteName, reporterConfig)
 }
 
 func AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, randomConfigDir string, waitingTime time.Duration) {

--- a/tests/lifecycle/lifecycle_suite_test.go
+++ b/tests/lifecycle/lifecycle_suite_test.go
@@ -3,9 +3,7 @@
 package lifecycle
 
 import (
-	"flag"
 	"os"
-	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,14 +19,7 @@ import (
 )
 
 func TestLifecycle(t *testing.T) {
-	_, currentFile, _, _ := runtime.Caller(0)
-	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
-	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
-
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CNFCert lifecycle tests", reporterConfig)
+	globalhelper.RunSuite(t, "CNFCert lifecycle tests")
 }
 
 var _ = SynchronizedBeforeSuite(func() {

--- a/tests/manageability/manageability_suite_test.go
+++ b/tests/manageability/manageability_suite_test.go
@@ -3,25 +3,13 @@
 package performance
 
 import (
-	"flag"
-	"runtime"
 	"testing"
-
-	. "github.com/onsi/ginkgo/v2"
 
 	_ "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/manageability/tests"
 
-	. "github.com/onsi/gomega"
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
 )
 
 func TestManageability(t *testing.T) {
-	_, currentFile, _, _ := runtime.Caller(0)
-	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
-	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
-
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CNFCert performance tests", reporterConfig)
+	globalhelper.RunSuite(t, "CNFCert performance tests")
 }

--- a/tests/networking/networking_suite_test.go
+++ b/tests/networking/networking_suite_test.go
@@ -3,8 +3,6 @@
 package networking
 
 import (
-	"flag"
-	"runtime"
 	"testing"
 	"time"
 
@@ -22,14 +20,7 @@ import (
 )
 
 func TestNetworking(t *testing.T) {
-	_, currentFile, _, _ := runtime.Caller(0)
-	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
-	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
-
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CNFCert networking tests", reporterConfig)
+	globalhelper.RunSuite(t, "CNFCert networking tests")
 }
 
 var _ = SynchronizedBeforeSuite(func() {

--- a/tests/observability/observability_suite_test.go
+++ b/tests/observability/observability_suite_test.go
@@ -3,9 +3,7 @@
 package observability
 
 import (
-	"flag"
 	"fmt"
-	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -18,14 +16,7 @@ import (
 )
 
 func TestObservability(t *testing.T) {
-	_, currentFile, _, _ := runtime.Caller(0)
-	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
-	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
-
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CNFCert observability tests", reporterConfig)
+	globalhelper.RunSuite(t, "CNFCert observability tests")
 }
 
 var _ = SynchronizedBeforeSuite(func() {

--- a/tests/operator/operator_suite_test.go
+++ b/tests/operator/operator_suite_test.go
@@ -3,8 +3,6 @@
 package operator
 
 import (
-	"flag"
-	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,14 +13,7 @@ import (
 )
 
 func TestOperator(t *testing.T) {
-	_, currentFile, _, _ := runtime.Caller(0)
-	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
-	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
-
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CNFCert operator tests", reporterConfig)
+	globalhelper.RunSuite(t, "CNFCert operator tests")
 }
 
 var _ = SynchronizedBeforeSuite(func() {

--- a/tests/performance/performance_suite_test.go
+++ b/tests/performance/performance_suite_test.go
@@ -3,26 +3,13 @@
 package performance
 
 import (
-	"flag"
-	"runtime"
 	"testing"
-
-	. "github.com/onsi/ginkgo/v2"
 
 	_ "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/performance/tests"
 
-	. "github.com/onsi/gomega"
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
 )
 
 func TestPerformance(t *testing.T) {
-	_, currentFile, _, _ := runtime.Caller(0)
-
-	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
-	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
-
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CNFCert performance tests", reporterConfig)
+	globalhelper.RunSuite(t, "CNFCert performance tests")
 }

--- a/tests/platformalteration/platform_alteration_suite_test.go
+++ b/tests/platformalteration/platform_alteration_suite_test.go
@@ -3,8 +3,6 @@
 package platformalteration
 
 import (
-	"flag"
-	"runtime"
 	"testing"
 	"time"
 
@@ -22,14 +20,7 @@ import (
 )
 
 func TestPlatformAlteration(t *testing.T) {
-	_, currentFile, _, _ := runtime.Caller(0)
-	_ = flag.Lookup("logtostderr").Value.Set("true")
-	_ = flag.Lookup("v").Value.Set(globalhelper.GetConfiguration().General.VerificationLogLevel)
-	_, reporterConfig := GinkgoConfiguration()
-	reporterConfig.JUnitReport = globalhelper.GetConfiguration().GetReportPath(currentFile)
-
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CNFCert platform-alteration tests", reporterConfig)
+	globalhelper.RunSuite(t, "CNFCert platform-alteration tests")
 }
 
 var _ = SynchronizedBeforeSuite(func() {


### PR DESCRIPTION
## Summary

- Add globalhelper.RunSuite(t, suiteName) that handles logging flags, JUnit report configuration, and Ginkgo test runner setup
- Replace duplicated TestXXX boilerplate in all 9 suite_test.go files with a single RunSuite call
- Net reduction of ~70 lines of duplicated code across the test suites
- Uses runtime.Caller(1) to preserve correct JUnit report paths from the caller file location

## Test plan

- [ ] make lint passes
- [ ] make test passes (pre-existing test failure in TestDebugCertsuite is unrelated)
- [ ] Verify JUnit report paths are still correct in CI output