### PR TITLE
refactor: replace time.Sleep polling with wait.PollUntilContextTimeout

### DIFF
--- a/tests/globalhelper/catalogsources.go
+++ b/tests/globalhelper/catalogsources.go
@@ -12,6 +12,7 @@ import (
 	v1alpha1typed "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1alpha1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	klog "k8s.io/klog/v2"
 )
 
@@ -31,54 +32,42 @@ func validateCatalogSources(opclient v1alpha1typed.OperatorsV1alpha1Interface) e
 		interval = 10 * time.Second
 	)
 
-	deadline := time.Now().Add(timeout)
-
-	for time.Now().Before(deadline) {
-		catalogSources, err := opclient.CatalogSources(
-			CatalogSourceNamespace).List(context.TODO(),
-			metav1.ListOptions{})
-		if err != nil {
-			return err
-		}
-
-		allReady := true
-
-		for _, name := range requiredCatalogSources {
-			idx := slices.IndexFunc(catalogSources.Items, func(cs v1alpha1.CatalogSource) bool {
-				return cs.Name == name
-			})
-
-			if idx == -1 {
-				klog.Infof("Catalog source %s not found yet, waiting...", name)
-				allReady = false
-
-				break
+	return wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			catalogSources, err := opclient.CatalogSources(
+				CatalogSourceNamespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return false, err
 			}
 
-			cs := catalogSources.Items[idx]
-			if cs.Status.GRPCConnectionState == nil || cs.Status.GRPCConnectionState.LastObservedState != "READY" {
-				state := "nil"
-				if cs.Status.GRPCConnectionState != nil {
-					state = cs.Status.GRPCConnectionState.LastObservedState
+			for _, name := range requiredCatalogSources {
+				idx := slices.IndexFunc(catalogSources.Items, func(cs v1alpha1.CatalogSource) bool {
+					return cs.Name == name
+				})
+
+				if idx == -1 {
+					klog.Infof("Catalog source %s not found yet, waiting...", name)
+
+					return false, nil
 				}
 
-				klog.Infof("Catalog source %s exists but is not READY (state: %s), waiting...", name, state)
-				allReady = false
+				cs := catalogSources.Items[idx]
+				if cs.Status.GRPCConnectionState == nil || cs.Status.GRPCConnectionState.LastObservedState != "READY" {
+					state := "nil"
+					if cs.Status.GRPCConnectionState != nil {
+						state = cs.Status.GRPCConnectionState.LastObservedState
+					}
 
-				break
+					klog.Infof("Catalog source %s exists but is not READY (state: %s), waiting...", name, state)
+
+					return false, nil
+				}
+
+				klog.Infof("Catalog source %s is READY", name)
 			}
 
-			klog.Infof("Catalog source %s is READY", name)
-		}
-
-		if allReady {
-			return nil
-		}
-
-		time.Sleep(interval)
-	}
-
-	return fmt.Errorf("timed out after %s waiting for catalog sources %v to be READY", timeout, requiredCatalogSources)
+			return true, nil
+		})
 }
 
 func deleteCatalogSourceByName(name string) error {

--- a/tests/globalhelper/pod.go
+++ b/tests/globalhelper/pod.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	klog "k8s.io/klog/v2"
 
@@ -180,40 +181,36 @@ func getRunningPod(client typedcorev1.CoreV1Interface, namespace, name string) (
 }
 
 func GetControllerPodFromOperator(namespace, operatorName string) (*corev1.Pod, error) {
-	// Wait for the controller manager pod to come up
-	podsFound := false
-
-	var (
-		pods *corev1.PodList
-		err  error
+	const (
+		podDiscoveryTimeout  = 50 * time.Second
+		podDiscoveryInterval = 5 * time.Second
 	)
 
-	// Try 10 times to find the pod
-	for i := 0; i < 10; i++ {
-		pods, err = GetListOfPodsInNamespace(namespace)
-		if err != nil {
-			return nil, err
-		}
+	var pods *corev1.PodList
 
-		if len(pods.Items) == 0 {
-			fmt.Println("No pods found, retrying in 5 seconds...")
-			time.Sleep(5 * time.Second)
+	err := wait.PollUntilContextTimeout(context.TODO(), podDiscoveryInterval, podDiscoveryTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			var listErr error
+			//nolint:contextcheck // GetListOfPodsInNamespace does not accept a context yet
+			pods, listErr = GetListOfPodsInNamespace(namespace)
 
-			continue
-		} else {
-			podsFound = true
+			if listErr != nil {
+				return false, listErr
+			}
 
-			break
-		}
-	}
+			if len(pods.Items) == 0 {
+				klog.Infof("No pods found in namespace %s, retrying...", namespace)
 
-	if !podsFound {
-		return nil, fmt.Errorf("no pods found in namespace %s", namespace)
+				return false, nil
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("no pods found in namespace %s: %w", namespace, err)
 	}
 
 	for _, pod := range pods.Items {
-		fmt.Printf("Checking pod %s\n", pod.Name)
-
 		if strings.Contains(pod.Name, operatorName) {
 			return &pod, nil
 		}

--- a/tests/platformalteration/helper/helper.go
+++ b/tests/platformalteration/helper/helper.go
@@ -148,26 +148,15 @@ func UpdateAndVerifyHugePagesConfig(updatedHugePagesNumber int, filePath string,
 		return fmt.Errorf("failed to execute command %s: %w", cmd, err)
 	}
 
-	// loop to wait until the file has been actually updated.
-	timeout := time.Now().Add(5 * time.Minute)
+	return wait.PollUntilContextTimeout(context.TODO(), tsparams.RetryInterval*time.Second, WaitingTime, true,
+		func(ctx context.Context) (bool, error) {
+			currentHugepagesNumber, err := GetHugePagesConfigNumber(filePath, pod)
+			if err != nil {
+				return false, fmt.Errorf("failed to get hugepages number: %w", err)
+			}
 
-	for {
-		currentHugepagesNumber, err := GetHugePagesConfigNumber(filePath, pod)
-		if err != nil {
-			return fmt.Errorf("failed to get hugepages number: %w", err)
-		}
-
-		if updatedHugePagesNumber == currentHugepagesNumber {
-			return nil
-		}
-
-		if time.Now().After(timeout) {
-			return fmt.Errorf("timedout waiting for hugepages to be updated, currently: %d, expected: %d",
-				currentHugepagesNumber, updatedHugePagesNumber)
-		}
-
-		time.Sleep(tsparams.RetryInterval * time.Second)
-	}
+			return updatedHugePagesNumber == currentHugepagesNumber, nil
+		})
 }
 
 // GetHugePagesConfigNumber returns hugepages config number from a given file.


### PR DESCRIPTION
## Summary

- Replace 3 manual time.Sleep polling loops with wait.PollUntilContextTimeout
- catalogsources.go: manual deadline loop for catalog source readiness
- pod.go: fixed-count retry loop for operator pod discovery
- platformalteration/helper.go: manual deadline loop for hugepages config verification
- All now use the standard k8s wait pattern that supports context cancellation

## Test plan

- [ ] make lint passes
- [ ] make test passes (pre-existing test failure in TestDebugCertsuite is unrelated)
- [ ] Verify catalog source, pod discovery, and hugepages polling works in integration tests