### PR TITLE
refactor: consolidate duplicate timeout constants into globalparameters

### DIFF
--- a/tests/accesscontrol/parameters/parameters.go
+++ b/tests/accesscontrol/parameters/parameters.go
@@ -3,10 +3,12 @@ package parameters
 import (
 	"fmt"
 	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
 const (
-	Timeout = 5 * time.Minute
+	Timeout = globalparameters.DefaultTimeout
 )
 
 var (

--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -3,6 +3,8 @@ package parameters
 import (
 	"fmt"
 	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
 type (
@@ -19,7 +21,7 @@ type (
 )
 
 const (
-	Timeout         = 5 * time.Minute
+	Timeout         = globalparameters.DefaultTimeout
 	TimeoutLabelCsv = 2 * time.Minute
 	PollingInterval = 5 * time.Second
 

--- a/tests/globalparameters/globalparameters.go
+++ b/tests/globalparameters/globalparameters.go
@@ -3,10 +3,13 @@ package globalparameters
 import (
 	"encoding/xml"
 	"io/fs"
+	"time"
 )
 
 const (
-	DirPermissions fs.FileMode = 0750
+	DirPermissions      fs.FileMode = 0750
+	DefaultTimeout                  = 5 * time.Minute
+	DefaultPollInterval             = 5 * time.Second
 )
 
 type (

--- a/tests/lifecycle/parameters/parameters.go
+++ b/tests/lifecycle/parameters/parameters.go
@@ -2,11 +2,12 @@ package parameters
 
 import (
 	"fmt"
-	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
 const (
-	WaitingTime   = 5 * time.Minute
+	WaitingTime   = globalparameters.DefaultTimeout
 	RetryInterval = 5
 )
 

--- a/tests/manageability/parameters/parameters.go
+++ b/tests/manageability/parameters/parameters.go
@@ -2,11 +2,12 @@ package parameters
 
 import (
 	"fmt"
-	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
 const (
-	WaitingTime = 5 * time.Minute
+	WaitingTime = globalparameters.DefaultTimeout
 )
 
 var (

--- a/tests/networking/parameters/parameters.go
+++ b/tests/networking/parameters/parameters.go
@@ -2,11 +2,12 @@ package parameters
 
 import (
 	"fmt"
-	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
 const (
-	WaitingTime   = 5 * time.Minute
+	WaitingTime   = globalparameters.DefaultTimeout
 	RetryInterval = 5
 )
 

--- a/tests/performance/parameters/parameters.go
+++ b/tests/performance/parameters/parameters.go
@@ -2,11 +2,12 @@ package parameters
 
 import (
 	"fmt"
-	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
 const (
-	WaitingTime = 5 * time.Minute
+	WaitingTime = globalparameters.DefaultTimeout
 )
 
 var (

--- a/tests/platformalteration/helper/helper.go
+++ b/tests/platformalteration/helper/helper.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 	tsparams "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/platformalteration/parameters"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
@@ -21,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-const WaitingTime = 5 * time.Minute
+const WaitingTime = globalparameters.DefaultTimeout
 
 // IsRealOCPCluster checks if the cluster is a real OCP cluster (not CRC/SNO development cluster).
 // Real clusters typically have multiple nodes or specific configurations that indicate

--- a/tests/platformalteration/parameters/parameters.go
+++ b/tests/platformalteration/parameters/parameters.go
@@ -3,10 +3,12 @@ package parameters
 import (
 	"fmt"
 	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
 const (
-	WaitingTime   = 5 * time.Minute
+	WaitingTime   = globalparameters.DefaultTimeout
 	RetryInterval = 5
 )
 


### PR DESCRIPTION
## Summary

- Add DefaultTimeout (5min) and DefaultPollInterval (5s) constants to globalparameters
- Update 7 suite parameter files to reference globalparameters.DefaultTimeout instead of duplicating 5 * time.Minute
- Remove duplicate WaitingTime constant in platformalteration/helper that shadowed the parameters version
- Remove unused time import from 4 parameter files where it was only needed for the timeout constant

## Test plan

- [ ] make lint passes
- [ ] make test passes (pre-existing test failure in TestDebugCertsuite is unrelated)
- [ ] Verify timeout behavior unchanged in integration tests