### PR TITLE
refactor: centralize container image constants into globalparameters

### DIFF
--- a/tests/accesscontrol/parameters/parameters.go
+++ b/tests/accesscontrol/parameters/parameters.go
@@ -19,7 +19,7 @@ var (
 	InvalidNamespace                     = "openshift-test"
 	AdditionalValidNamespace             = "ac-test"
 	AdditionalNamespaceForResourceQuotas = "ac-rq-test"
-	SampleWorkloadImage                  = "registry.access.redhat.com/ubi8/ubi-micro:latest"
+	SampleWorkloadImage                  = globalparameters.UBIMicroImage
 
 	TestDeploymentLabels = map[string]string{
 		testPodLabelPrefixName: testPodLabelValue,
@@ -77,7 +77,7 @@ const (
 
 	TestAccessControlNameSpace = "accesscontrol-tests"
 
-	SSHDaemonImageName = "quay.io/testnetworkfunction/k8s-best-practices-debug:latest"
+	SSHDaemonImageName = globalparameters.DebugImage
 
 	ServiceAccountName = "automount-test-sa"
 	MemoryLimit        = "112Mi"

--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -25,7 +25,7 @@ const (
 	TimeoutLabelCsv = 2 * time.Minute
 	PollingInterval = 5 * time.Second
 
-	SampleWorkloadImage = "registry.access.redhat.com/ubi8/ubi-micro:latest"
+	SampleWorkloadImage = globalparameters.UBIMicroImage
 )
 
 var (
@@ -48,7 +48,7 @@ var (
 	ContainerRepoOnlyRedHatRegistry     = ";registry.connect.redhat.com;;"
 	CertifiedContainerURLNodeJs         = "registry.access.redhat.com/ubi8/nodejs-12:latest"
 	CertifiedContainerURLCockroachDB    = "registry.connect.redhat.com/cockroachdb/cockroach:v23.1.17" // 'latest' tag is not available
-	UncertifiedContainerURLCnfTest      = "quay.io/testnetworkfunction/k8s-best-practices-debug:latest"
+	UncertifiedContainerURLCnfTest      = globalparameters.DebugImage
 
 	TestCaseOperatorAffiliatedCertName = "affiliated-certification-operator-is-certified"
 	TestHelmChartCertified             = "affiliated-certification-helmchart-is-certified"

--- a/tests/globalparameters/globalparameters.go
+++ b/tests/globalparameters/globalparameters.go
@@ -10,6 +10,10 @@ const (
 	DirPermissions      fs.FileMode = 0750
 	DefaultTimeout                  = 5 * time.Minute
 	DefaultPollInterval             = 5 * time.Second
+
+	UBIMicroImage                = "registry.access.redhat.com/ubi8/ubi-micro:latest"
+	CertsuiteSampleWorkloadImage = "quay.io/redhat-best-practices-for-k8s/certsuite-sample-workload"
+	DebugImage                   = "quay.io/testnetworkfunction/k8s-best-practices-debug:latest"
 )
 
 type (

--- a/tests/lifecycle/parameters/parameters.go
+++ b/tests/lifecycle/parameters/parameters.go
@@ -66,5 +66,5 @@ const (
 	CertsuitePodTolerationBypassTcName           = "lifecycle-pod-toleration-bypass"
 	CertsuiteStorageProvisioner                  = "lifecycle-storage-provisioner"
 
-	SampleWorkloadImage = "registry.access.redhat.com/ubi8/ubi-micro:latest"
+	SampleWorkloadImage = globalparameters.UBIMicroImage
 )

--- a/tests/manageability/parameters/parameters.go
+++ b/tests/manageability/parameters/parameters.go
@@ -31,5 +31,5 @@ const (
 	CertsuiteContainerPortName = "manageability-container-port-name-format"
 	CertsuiteContainerImageTag = "manageability-containers-image-tag"
 
-	SampleWorkloadImage = "registry.access.redhat.com/ubi8/ubi-micro:latest"
+	SampleWorkloadImage = globalparameters.UBIMicroImage
 )

--- a/tests/networking/parameters/parameters.go
+++ b/tests/networking/parameters/parameters.go
@@ -75,5 +75,5 @@ const (
 	CertsuiteNetworkingMultusIpamTcName           = "networking-multus-ipam"
 	CertsuiteNetworkingMultusNodeSelectorTcName   = "networking-multus-node-selector"
 
-	SampleWorkloadImage = "registry.access.redhat.com/ubi8/ubi-micro:latest"
+	SampleWorkloadImage = globalparameters.UBIMicroImage
 )

--- a/tests/observability/parameters/parameters.go
+++ b/tests/observability/parameters/parameters.go
@@ -1,6 +1,10 @@
 package parameters
 
-import "time"
+import (
+	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
+)
 
 const (
 	CertsuiteTestSuiteName = "observability"
@@ -12,7 +16,7 @@ const (
 	CertsuiteTerminationMsgPolicyTcName = "observability-termination-policy"
 	CertsuitePodDisruptionBudgetTcName  = "observability-pod-disruption-budget"
 
-	SampleWorkloadImage = "registry.access.redhat.com/ubi8/ubi-micro:latest"
+	SampleWorkloadImage = globalparameters.UBIMicroImage
 
 	TestNamespace = "observability-ns"
 

--- a/tests/operator/parameters/parameters.go
+++ b/tests/operator/parameters/parameters.go
@@ -3,6 +3,8 @@ package parameters
 import (
 	"fmt"
 	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
 type (
@@ -77,7 +79,7 @@ const (
 	TestOperatorHubSubscriptionValidChannel = "operator-hub-subscription-is-valid-channel"
 	TestOperatorSingleCrdOwner              = "operator-single-crd-owner"
 
-	SampleWorkloadImage = "registry.access.redhat.com/ubi8/ubi-micro:latest"
+	SampleWorkloadImage = globalparameters.UBIMicroImage
 )
 
 const (

--- a/tests/performance/parameters/parameters.go
+++ b/tests/performance/parameters/parameters.go
@@ -26,7 +26,7 @@ const (
 	CertsuiteTestSuiteName = "performance"
 	PerformanceNamespace   = "performance-ns"
 
-	RtImageName = "quay.io/testnetworkfunction/k8s-best-practices-debug:latest"
+	RtImageName = globalparameters.DebugImage
 
 	// CRD names for prerequisite checks.
 	PerformanceProfileCrd = "performanceprofiles.performance.openshift.io"

--- a/tests/platformalteration/parameters/parameters.go
+++ b/tests/platformalteration/parameters/parameters.go
@@ -57,7 +57,7 @@ const (
 	FindHugePagesFiles    = "find /host/sys/devices/system/node/ -name nr_hugepages"
 	PerformanceProfileCrd = "performanceprofiles.performance.openshift.io"
 
-	SampleWorkloadImage = "registry.access.redhat.com/ubi8/ubi-micro:latest"
+	SampleWorkloadImage = globalparameters.UBIMicroImage
 
 	IstioVersion = "1.30.1"
 )


### PR DESCRIPTION
## Summary

- Add UBIMicroImage, CertsuiteSampleWorkloadImage, and DebugImage constants to globalparameters
- Update 8 suite parameter files to reference globalparameters.UBIMicroImage instead of duplicating the UBI micro image string
- Update 3 parameter files to reference globalparameters.DebugImage for the debug/SSH daemon image
- Suite-specific images (CockroachDB, NotRedHatRelease, etc.) left in place intentionally

Depends on #1509 (consolidate timeout constants) which also modifies globalparameters.go.

## Test plan

- [ ] make lint passes
- [ ] make test passes (pre-existing test failure in TestDebugCertsuite is unrelated)
- [ ] Verify container images resolve correctly in integration tests