### PR TITLE
fix: add early returns on error in CopyClaimFileToTcFolder

### DIFF
--- a/tests/globalhelper/reporthelper.go
+++ b/tests/globalhelper/reporthelper.go
@@ -181,12 +181,15 @@ func CopyClaimFileToTcFolder(tcName, formattedTcName, reportDir string) {
 	_, err := os.Stat(srcClaim)
 	if err != nil {
 		klog.Error("file does not exist ", srcClaim)
+
+		return
 	}
 
-	// create destination folder
 	err = os.MkdirAll(dstDir, globalparameters.DirPermissions)
 	if err != nil {
 		klog.ErrorS(err, "could not create dest directory", "dir", dstDir)
+
+		return
 	}
 
 	err = CopyFiles(srcClaim, dstClaim)


### PR DESCRIPTION
## Summary
- Add early returns after each error in CopyClaimFileToTcFolder to prevent cascading failures (e.g., trying to copy when source file is missing or dest directory creation failed)

## Test plan
- [ ] make lint passes
- [ ] make test passes