### PR TITLE
fix: include error value in daemonset readiness log message

### DIFF
--- a/tests/globalhelper/daemonset.go
+++ b/tests/globalhelper/daemonset.go
@@ -37,7 +37,7 @@ func createAndWaitUntilDaemonSetIsReady(client *egiClients.Settings,
 		status, err := isDaemonSetReady(client, runningDaemonSet.Namespace, runningDaemonSet.Name)
 		if err != nil {
 			klog.Errorf(
-				"daemonset %s is not ready, retry in 1 second", runningDaemonSet.Name)
+				"daemonset %s is not ready, retry in 1 second: %v", runningDaemonSet.Name, err)
 
 			return false
 		}


### PR DESCRIPTION
## Summary
- Add missing error value to klog.Errorf in daemonset readiness polling — the error from isDaemonSetReady was silently discarded

## Test plan
- [ ] make lint passes
- [ ] make test passes