### PR TITLE
refactor: consolidate openshift-marketplace namespace to single constant

### DIFF
--- a/tests/affiliatedcertification/parameters/parameters.go
+++ b/tests/affiliatedcertification/parameters/parameters.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
@@ -57,7 +58,7 @@ var (
 	CertifiedOperatorGroup             = "certified-operators"
 	CertifiedOperatorDisplayName       = "Certified Operators"
 	CommunityOperatorGroup             = "community-operators"
-	OperatorSourceNamespace            = "openshift-marketplace"
+	OperatorSourceNamespace            = globalhelper.CatalogSourceNamespace
 	OperatorLabel                      = map[string]string{"redhat-best-practices-for-k8s.com/operator": "target"}
 	CertifiedOperatorPrefix            = "grafana-operator"
 	UncertifiedOperatorPrefixSriov     = "sriov-fec"

--- a/tests/globalhelper/operator.go
+++ b/tests/globalhelper/operator.go
@@ -122,7 +122,7 @@ func deployRHCatalogSource(name, imagePath, displayName, ocpVersion string) erro
 		&v1alpha1.CatalogSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
-				Namespace: "openshift-marketplace",
+				Namespace: CatalogSourceNamespace,
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType:  "grpc",
@@ -149,7 +149,7 @@ func deployRHCatalogSource(name, imagePath, displayName, ocpVersion string) erro
 }
 
 func DeleteCustomOperatorSource() error {
-	return DeleteCatalogSource("custom-catalog", "openshift-marketplace", "Custom Index")
+	return DeleteCatalogSource("custom-catalog", CatalogSourceNamespace, "Custom Index")
 }
 
 func DeployCustomOperatorSource(image string) error {
@@ -157,7 +157,7 @@ func DeployCustomOperatorSource(image string) error {
 		&v1alpha1.CatalogSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "custom-catalog",
-				Namespace: "openshift-marketplace",
+				Namespace: CatalogSourceNamespace,
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				SourceType:  "grpc",

--- a/tests/operator/parameters/parameters.go
+++ b/tests/operator/parameters/parameters.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
 	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
 )
 
@@ -42,7 +43,7 @@ var (
 	CertifiedOperatorGroup               = "certified-operators"
 	RedhatOperatorGroup                  = "redhat-operators"
 	CommunityOperatorGroup               = "community-operators"
-	OperatorSourceNamespace              = "openshift-marketplace"
+	OperatorSourceNamespace              = globalhelper.CatalogSourceNamespace
 	OperatorPrefixLightweight            = "prometheus-exporter-operator"
 	OperatorPrefixKiali                  = "kiali-operator"
 	CertifiedOperatorPrefix              = "grafana-operator"

--- a/tests/utils/operatorversions/operatorversions.go
+++ b/tests/utils/operatorversions/operatorversions.go
@@ -19,7 +19,6 @@ const (
 	CatalogCertifiedOperators = "certified-operators"
 	CatalogCommunityOperators = "community-operators"
 	CatalogRedHatOperators    = "redhat-operators"
-	CatalogSourceNamespace    = "openshift-marketplace"
 )
 
 // OperatorInfo contains the configuration for a specific operator.


### PR DESCRIPTION
## Summary
- Replace 3 hardcoded openshift-marketplace strings in operator.go with the existing CatalogSourceNamespace constant
- Point OperatorSourceNamespace in operator and affiliatedcertification parameter files at the shared constant
- Remove unused duplicate CatalogSourceNamespace from operatorversions.go

## Test plan
- [ ] make lint passes
- [ ] make test passes