### PR TITLE
chore: remove stale commented-out debug code in AfterEachCleanup

### DIFF
--- a/tests/globalhelper/init.go
+++ b/tests/globalhelper/init.go
@@ -134,14 +134,6 @@ func RunSuite(t *testing.T, suiteName string) {
 }
 
 func AfterEachCleanupWithRandomNamespace(randomNamespace, randomReportDir, randomConfigDir string, waitingTime time.Duration) {
-	// logfile := "certsuite.log"
-	// By("Print logs")
-	// myFile, err := os.ReadFile(randomReportDir + "/" + logfile)
-	// if err != nil {
-	// 	klog.Errorf("can not read file %s - %s", logfile, err)
-	// }
-	// fmt.Println(string(myFile))
-	// By(fmt.Sprintf("Remove reports from report directory: %s", randomReportDir))
 	err := RemoveContentsFromReportDir(randomReportDir)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## Summary
- Delete 8-line abandoned log-printing block that was commented out in AfterEachCleanupWithRandomNamespace

## Test plan
- [ ] make lint passes
- [ ] make test passes