### PR TITLE
refactor: wrap bare exec.Command calls in globalhelper.RunShellCommand

### DIFF
--- a/tests/affiliatedcertification/affiliated_certification_suite_test.go
+++ b/tests/affiliatedcertification/affiliated_certification_suite_test.go
@@ -5,7 +5,6 @@ package affiliatedcertification
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,12 +36,11 @@ var _ = SynchronizedBeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred(), "Error creating temp dir for helm")
 
 		By("Install helm v3 to isolated temp directory")
-		cmd := exec.Command("/bin/bash", "-c",
-			"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"+
-				" && chmod +x get_helm.sh"+
-				" && HELM_INSTALL_DIR="+helmDir+" USE_SUDO=false ./get_helm.sh")
-		out, err := cmd.CombinedOutput()
-		Expect(err).ToNot(HaveOccurred(), "Error installing helm v3: "+string(out))
+		_, err = globalhelper.RunShellCommand(
+			"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3" +
+				" && chmod +x get_helm.sh" +
+				" && HELM_INSTALL_DIR=" + helmDir + " USE_SUDO=false ./get_helm.sh")
+		Expect(err).ToNot(HaveOccurred(), "Error installing helm v3")
 
 		By("Prepend helm temp directory to PATH")
 		err = os.Setenv("PATH", helmDir+":"+os.Getenv("PATH"))

--- a/tests/affiliatedcertification/tests/affiliated_certification_helm_version.go
+++ b/tests/affiliatedcertification/tests/affiliated_certification_helm_version.go
@@ -47,19 +47,15 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, Label("affili
 	// 68120
 	It("installed helm version is certified", func() {
 		By("Check if helm is installed")
-		cmd := exec.Command("/bin/bash", "-c",
-			"helm version")
+		_, err := globalhelper.RunShellCommand("helm version")
 
-		err := cmd.Run()
 		if err != nil {
 			Skip("helm does not exist please install it to run the test.")
 		}
 
 		By("Check that helm version is v3")
-		cmd = exec.Command("/bin/bash", "-c",
-			"helm version --short | grep v3")
+		_, err = globalhelper.RunShellCommand("helm version --short | grep v3")
 
-		err = cmd.Run()
 		if err != nil {
 			Fail("Helm version is not v3")
 		}
@@ -88,12 +84,11 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, Label("affili
 		Expect(err).ToNot(HaveOccurred(), "Error removing helm binary")
 
 		By("Install helm v2")
-		cmd := exec.Command("/bin/bash", "-c",
-			"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get"+
-				" && chmod +x get_helm.sh"+
-				" && HELM_INSTALL_DIR="+helmInstallDir+" USE_SUDO=false ./get_helm.sh --version v2.17.0"+
+		_, err = globalhelper.RunShellCommand(
+			"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get" +
+				" && chmod +x get_helm.sh" +
+				" && HELM_INSTALL_DIR=" + helmInstallDir + " USE_SUDO=false ./get_helm.sh --version v2.17.0" +
 				" && helm init")
-		err = cmd.Run()
 		Expect(err).ToNot(HaveOccurred(), "Error installing helm v2")
 
 		DeferCleanup(func() {
@@ -102,11 +97,10 @@ var _ = Describe("Affiliated-certification helm-version,", Serial, Label("affili
 			Expect(err).ToNot(HaveOccurred(), "Error deleting tiller deployment")
 
 			By("Re-install helm v3")
-			cmd = exec.Command("/bin/bash", "-c",
-				"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"+
-					" && chmod +x get_helm.sh"+
-					" && HELM_INSTALL_DIR="+helmInstallDir+" USE_SUDO=false ./get_helm.sh")
-			err = cmd.Run()
+			_, err = globalhelper.RunShellCommand(
+				"curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3" +
+					" && chmod +x get_helm.sh" +
+					" && HELM_INSTALL_DIR=" + helmInstallDir + " USE_SUDO=false ./get_helm.sh")
 			Expect(err).ToNot(HaveOccurred(), "Error installing helm v3")
 		})
 

--- a/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
+++ b/tests/affiliatedcertification/tests/affillated_certification_helm_chart.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"os/exec"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tshelper "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/affiliatedcertification/helper"
@@ -46,41 +44,34 @@ var _ = Describe("Affiliated-certification helm chart certification,", Serial,
 
 		It("One helm to test, are certified", func() {
 			By("Check if helm is installed")
-			cmd := exec.Command("/bin/bash", "-c",
-				"helm version")
+			_, err := globalhelper.RunShellCommand("helm version")
 
-			err := cmd.Run()
 			if err != nil {
 				Skip("helm does not exist please install it to run the test.")
 			}
 
 			By("Check that helm version is v3")
-			cmd = exec.Command("/bin/bash", "-c",
-				"helm version --short | grep v3")
+			_, err = globalhelper.RunShellCommand("helm version --short | grep v3")
 
-			err = cmd.Run()
 			if err != nil {
 				Fail("Helm version is not v3")
 			}
 
 			By("Add openshift-helm-charts repo")
-			cmd = exec.Command("/bin/bash", "-c",
-				"helm repo add hashicorp https://helm.releases.hashicorp.com --force-update "+
-					"&& helm repo update")
-			err = cmd.Run()
+			_, err = globalhelper.RunShellCommand(
+				"helm repo add hashicorp https://helm.releases.hashicorp.com --force-update" +
+					" && helm repo update")
 			Expect(err).ToNot(HaveOccurred(), "Error adding openshift-helm-carts repo")
 
 			By("Install helm chart")
-			cmd = exec.Command("/bin/bash", "-c",
-				"helm install example-vault1 hashicorp/vault -n "+randomNamespace)
-			err = cmd.Run()
+			_, err = globalhelper.RunShellCommand(
+				"helm install example-vault1 hashicorp/vault -n " + randomNamespace)
 			Expect(err).ToNot(HaveOccurred(), "Error installing hashicorp-vault helm chart")
 
 			DeferCleanup(func() {
 				By("Remove the example-vault1 helm chart")
-				cmd = exec.Command("/bin/bash", "-c", // uninstall the chart
-					"helm uninstall example-vault1 --ignore-not-found -n "+randomNamespace)
-				err = cmd.Run()
+				_, err = globalhelper.RunShellCommand(
+					"helm uninstall example-vault1 --ignore-not-found -n " + randomNamespace)
 				Expect(err).ToNot(HaveOccurred(), "Error uninstalling helm chart")
 
 				By("Delete clusterrole and clusterrolebinding")
@@ -113,21 +104,17 @@ var _ = Describe("Affiliated-certification helm chart certification,", Serial,
 
 		It("One helm to test, chart not certified", func() {
 			By("Check if helm is installed")
-			cmd := exec.Command("/bin/bash", "-c",
-				"helm version")
+			_, err := globalhelper.RunShellCommand("helm version")
 
-			out, err := cmd.CombinedOutput()
 			if err != nil {
-				Skip("helm does not exist please install it to run the test. Output: " + string(out))
+				Skip("helm does not exist please install it to run the test.")
 			}
 
 			By("Check that helm version is v3")
-			cmd = exec.Command("/bin/bash", "-c",
-				"helm version --short | grep v3")
+			_, err = globalhelper.RunShellCommand("helm version --short | grep v3")
 
-			out, err = cmd.CombinedOutput()
 			if err != nil {
-				Fail("Helm version is not v3. Output: " + string(out))
+				Fail("Helm version is not v3")
 			}
 
 			By("Delete istio-system namespace")
@@ -139,18 +126,16 @@ var _ = Describe("Affiliated-certification helm chart certification,", Serial,
 			Expect(err).ToNot(HaveOccurred(), "Error creating istio-system namespace")
 
 			By("Add istio helm chart repo")
-			cmd = exec.Command("/bin/bash", "-c",
-				"helm repo add istio https://istio-release.storage.googleapis.com/charts --force-update "+
-					"&& helm repo update")
-			out, err = cmd.CombinedOutput()
-			Expect(err).ToNot(HaveOccurred(), "Error adding istio charts repo. Output: %s", string(out))
+			_, err = globalhelper.RunShellCommand(
+				"helm repo add istio https://istio-release.storage.googleapis.com/charts --force-update" +
+					" && helm repo update")
+			Expect(err).ToNot(HaveOccurred(), "Error adding istio charts repo")
 
 			DeferCleanup(func() {
 				By("Remove istio-base helm chart")
-				cmd = exec.Command("/bin/bash", "-c", // uninstall the chart
-					"helm uninstall istio-base --ignore-not-found -n "+randomNamespace)
-				out, err := cmd.CombinedOutput()
-				Expect(err).ToNot(HaveOccurred(), "Error uninstalling helm chart. Output: %s", string(out))
+				_, err := globalhelper.RunShellCommand(
+					"helm uninstall istio-base --ignore-not-found -n " + randomNamespace)
+				Expect(err).ToNot(HaveOccurred(), "Error uninstalling helm chart")
 
 				By("Delete istio-system namespace")
 				err = globalhelper.DeleteNamespaceAndWait("istio-system", tsparams.Timeout)
@@ -168,11 +153,10 @@ var _ = Describe("Affiliated-certification helm chart certification,", Serial,
 			})
 
 			By("Install istio-base helm chart")
-			cmd = exec.Command("/bin/bash", "-c",
-				"helm install istio-base istio/base --set defaultRevision=default -n "+randomNamespace+
+			_, err = globalhelper.RunShellCommand(
+				"helm install istio-base istio/base --set defaultRevision=default -n " + randomNamespace +
 					" --set hub=gcr.io/istio-release")
-			out, err = cmd.CombinedOutput()
-			Expect(err).ToNot(HaveOccurred(), "Error installing istio-base helm chart. Output: %s", string(out))
+			Expect(err).ToNot(HaveOccurred(), "Error installing istio-base helm chart")
 
 			By("Start test")
 			err = globalhelper.LaunchTests(

--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -454,3 +454,14 @@ func IsCRCCluster() bool {
 
 	return false
 }
+
+func RunShellCommand(script string) (string, error) {
+	klog.V(5).Infof("Running shell command: %s", script)
+
+	output, err := exec.CommandContext(context.TODO(), "/bin/bash", "-c", script).CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("shell command failed: %w\nCommand: %s\nOutput: %s", err, script, string(output))
+	}
+
+	return string(output), nil
+}

--- a/tests/platformalteration/tests/platform_alteration_service_mesh.go
+++ b/tests/platformalteration/tests/platform_alteration_service_mesh.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,11 +34,10 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", Ordered, La
 	BeforeAll(func() {
 		if _, exists := os.LookupEnv("NON_LINUX_ENV"); !exists {
 			By("Install istio")
-			cmd := exec.Command("/bin/bash", "-c",
+			_, err := globalhelper.RunShellCommand(
 				fmt.Sprintf("curl -L https://istio.io/downloadIstio | ISTIO_VERSION=%s sh - "+
 					"&& istio-%s/bin/istioctl install --set profile=demo -y --set hub=gcr.io/istio-release",
 					tsparams.IstioVersion, tsparams.IstioVersion))
-			err := cmd.Run()
 			Expect(err).ToNot(HaveOccurred(), "Error installing istio")
 		}
 	})
@@ -47,11 +45,10 @@ var _ = Describe("platform-alteration-service-mesh-usage-installed", Ordered, La
 	AfterAll(func() {
 		if _, exists := os.LookupEnv("NON_LINUX_ENV"); !exists {
 			By("Uninstall istio")
-			cmd := exec.Command("/bin/bash", "-c",
+			_, err := globalhelper.RunShellCommand(
 				fmt.Sprintf("curl -L https://istio.io/downloadIstio | ISTIO_VERSION=%s sh - "+
 					"&& istio-%s/bin/istioctl uninstall -y --purge",
 					tsparams.IstioVersion, tsparams.IstioVersion))
-			err := cmd.Run()
 			Expect(err).ToNot(HaveOccurred(), "Error uninstalling istio")
 		}
 	})
@@ -222,11 +219,10 @@ var _ = Describe("platform-alteration-service-mesh-usage-uninstalled", Serial, L
 			By("Uninstall istio")
 
 			if _, exists := os.LookupEnv("NON_LINUX_ENV"); !exists {
-				cmd := exec.Command("/bin/bash", "-c",
+				_, err := globalhelper.RunShellCommand(
 					fmt.Sprintf("curl -L https://istio.io/downloadIstio | ISTIO_VERSION=%s sh - "+
 						"&& istio-%s/bin/istioctl uninstall -y --purge",
 						tsparams.IstioVersion, tsparams.IstioVersion))
-				err := cmd.Run()
 				Expect(err).ToNot(HaveOccurred(), "Error uninstalling istio")
 			}
 		}


### PR DESCRIPTION
## Summary

- Add `globalhelper.RunShellCommand(script)` helper with consistent logging, error formatting (includes command and output), and single call pattern
- Replace 13 bare `exec.Command("/bin/bash", "-c", ...)` calls across helm and istio test files
- Remove unused `os/exec` imports from 2 files
- Net reduction of 17 lines while improving error diagnostics

## Test plan

- [ ] make lint passes
- [ ] make test passes
- [ ] Verify helm and istio test behavior unchanged in integration tests