### PR TITLE
refactor: use klog structured logging instead of fmt.Sprintf and fmt.Printf

### DIFF
--- a/tests/accesscontrol/tests/access_control_sys_nice_capability_check.go
+++ b/tests/accesscontrol/tests/access_control_sys_nice_capability_check.go
@@ -203,7 +203,7 @@ var _ = Describe("Access-control sys-nice_capability", Ordered, Serial,
 			Eventually(func() bool {
 				podList, err = globalhelper.GetListOfPodsInNamespace(randomNamespace)
 				if err != nil {
-					klog.Info(fmt.Sprintf("Failed to list pods in ns %s: %v", randomNamespace, err))
+					klog.Infof("Failed to list pods in ns %s: %v", randomNamespace, err)
 
 					return false
 				}
@@ -304,7 +304,7 @@ var _ = Describe("Access-control sys-nice_capability", Ordered, Serial,
 			Eventually(func() bool {
 				podList, err = globalhelper.GetListOfPodsInNamespace(randomNamespace)
 				if err != nil {
-					klog.Info(fmt.Sprintf("Failed to list pods in ns %s: %v", randomNamespace, err))
+					klog.Infof("Failed to list pods in ns %s: %v", randomNamespace, err)
 
 					return false
 				}
@@ -444,8 +444,8 @@ var _ = Describe("Access-control sys-nice_capability check, non-realtime kernel"
 		Eventually(func() bool {
 			podList, err = globalhelper.GetListOfPodsInNamespace(randomNamespace)
 			if err != nil {
-				klog.Info(fmt.Sprintf("Failed to list pods in ns %s: %v", randomNamespace, err))
-				klog.Info(fmt.Sprintf("Failed to list pods in ns %s: %v", randomNamespace, err))
+				klog.Infof("Failed to list pods in ns %s: %v", randomNamespace, err)
+				klog.Infof("Failed to list pods in ns %s: %v", randomNamespace, err)
 
 				return false
 			}

--- a/tests/globalhelper/daemonset.go
+++ b/tests/globalhelper/daemonset.go
@@ -26,7 +26,7 @@ func createAndWaitUntilDaemonSetIsReady(client *egiClients.Settings,
 	runningDaemonSet, err := client.AppsV1Interface.DaemonSets(daemonSet.Namespace).Create(
 		context.TODO(), daemonSet, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("daemonset %s already exists", daemonSet.Name))
+		klog.V(5).Infof("daemonset %s already exists", daemonSet.Name)
 
 		return nil
 	} else if err != nil {

--- a/tests/globalhelper/deployment.go
+++ b/tests/globalhelper/deployment.go
@@ -39,7 +39,7 @@ func createAndWaitUntilDeploymentIsReady(client *egiClients.Settings, deployment
 		metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("deployment %s already exists", deployment.Name))
+		klog.V(5).Infof("deployment %s already exists", deployment.Name)
 
 		return nil
 	} else if err != nil {
@@ -64,16 +64,16 @@ func createAndWaitUntilDeploymentIsReady(client *egiClients.Settings, deployment
 				context.TODO(), deployment.Name, metav1.GetOptions{})
 
 			if err != nil {
-				klog.V(5).Info(fmt.Sprintf(
-					"deployment %s is not running, retry in 1 second", deployment.Name))
+				klog.V(5).Infof(
+					"deployment %s is not running, retry in 1 second", deployment.Name)
 
 				continue
 			}
 
 			// If it is running, we can break the loop
 			if testDeployment.Status.ReadyReplicas == *testDeployment.Spec.Replicas {
-				klog.V(5).Info(fmt.Sprintf("deployment %s is running", testDeployment.Name))
-				klog.V(5).Info(fmt.Sprintf("deployment %s status: %v", testDeployment.Name, testDeployment.Status))
+				klog.V(5).Infof("deployment %s is running", testDeployment.Name)
+				klog.V(5).Infof("deployment %s status: %v", testDeployment.Name, testDeployment.Status)
 				running = true
 
 				break

--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -99,7 +99,7 @@ func ValidateIfReportsAreValidWithAcceptedStatuses(tcName string, acceptedStatus
 
 		testPassed, checkErr := checkFunc(tcName, *claimReport)
 		if checkErr == nil && testPassed {
-			klog.V(5).Info(fmt.Sprintf("Test case %q is in accepted status %q", tcName, status))
+			klog.V(5).Infof("Test case %q is in accepted status %q", tcName, status)
 
 			return nil
 		}
@@ -165,8 +165,8 @@ func DefineCertsuiteConfig(namespaces []string, targetPodLabels []string, target
 		return fmt.Errorf("failed to encode certsuite yaml config file on %s: %w", certsuiteConfigFilePath, err)
 	}
 
-	klog.V(5).Info(fmt.Sprintf("%s deployed under %s directory",
-		globalparameters.DefaultCertsuiteConfigFileName, configDir))
+	klog.V(5).Infof("%s deployed under %s directory",
+		globalparameters.DefaultCertsuiteConfigFileName, configDir)
 
 	return nil
 }
@@ -233,7 +233,7 @@ func defineCertifiedContainersInfo(config *globalparameters.CertsuiteConfig, cer
 		tag := strings.TrimSpace(repositoryRegistryTagDigest[2])
 		digest := strings.TrimSpace(repositoryRegistryTagDigest[3])
 
-		klog.V(5).Info(fmt.Sprintf("Adding container repository:%s registry:%s to configuration", repo, registry))
+		klog.V(5).Infof("Adding container repository:%s registry:%s to configuration", repo, registry)
 
 		config.Certifiedcontainerinfo = append(config.Certifiedcontainerinfo, globalparameters.CertifiedContainerRepoInfo{
 			Repository: repo,
@@ -303,7 +303,7 @@ func defineCrdFilters(config *globalparameters.CertsuiteConfig, crdSuffixes []st
 	}
 
 	for _, crdSuffix := range crdSuffixes {
-		klog.V(5).Info(fmt.Sprintf("Adding crd suffix %s to certsuite configuration file", crdSuffix))
+		klog.V(5).Infof("Adding crd suffix %s to certsuite configuration file", crdSuffix)
 
 		config.TargetCrdFilters = append(config.TargetCrdFilters, globalparameters.TargetCrdFilter{
 			NameSuffix: crdSuffix,

--- a/tests/globalhelper/mutatingwebhook.go
+++ b/tests/globalhelper/mutatingwebhook.go
@@ -21,7 +21,7 @@ func deleteMutatingWebhookConfiguration(client admissionregistrationtypedv1.Admi
 		metav1.DeleteOptions{},
 	)
 	if k8serrors.IsNotFound(err) {
-		klog.V(5).Info(fmt.Sprintf("mutating webhook configuration %s is not found", name))
+		klog.V(5).Infof("mutating webhook configuration %s is not found", name)
 
 		return nil
 	} else if err != nil {

--- a/tests/globalhelper/namespaces.go
+++ b/tests/globalhelper/namespaces.go
@@ -35,7 +35,7 @@ func WaitForNamespaceDeletion(cs corev1Typed.CoreV1Interface, nsName string, tim
 		func(ctx context.Context) (bool, error) {
 			_, err := cs.Namespaces().Get(ctx, nsName, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
-				klog.V(5).Info(fmt.Sprintf("namespaces %s is not found", nsName))
+				klog.V(5).Infof("namespaces %s is not found", nsName)
 
 				return true, nil
 			}

--- a/tests/globalhelper/packagemanifest.go
+++ b/tests/globalhelper/packagemanifest.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	egiOLM "github.com/openshift-kni/eco-goinfra/pkg/olm"
+	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,7 +20,7 @@ func QueryPackageManifestForVersion(operatorName, operatorNamespace, channel str
 
 	for _, item := range pkgManifest {
 		if item.Object.GetName() == operatorName {
-			fmt.Printf("Comparing %s with %s\n", item.Object.Status.DefaultChannel, channel)
+			klog.Infof("Comparing %s with %s", item.Object.Status.DefaultChannel, channel)
 
 			// skip if the default channel is not the one we are looking for
 			if item.Object.Status.DefaultChannel != channel {
@@ -27,7 +28,7 @@ func QueryPackageManifestForVersion(operatorName, operatorNamespace, channel str
 			}
 
 			for _, chanObj := range item.Object.Status.Channels {
-				fmt.Printf("Comparing name %s with channel %s\n", chanObj.Name, channel)
+				klog.Infof("Comparing name %s with channel %s", chanObj.Name, channel)
 
 				// skip if the name of the channel is not the one we are looking for
 				if chanObj.Name != channel {
@@ -73,7 +74,7 @@ func QueryPackageManifestForOperatorName(searchString, operatorNamespace string)
 
 	for _, item := range pkgManifest {
 		if strings.Contains(item.Object.GetName(), searchString) {
-			fmt.Printf("Found package: %s matching search string: %s\n", item.Object.GetName(), searchString)
+			klog.Infof("Found package: %s matching search string: %s", item.Object.GetName(), searchString)
 
 			return item.Object.GetName(), nil
 		}
@@ -97,7 +98,7 @@ func QueryPackageManifestForOperatorNameAndCatalogSource(searchString, operatorN
 		if strings.HasPrefix(item.Object.GetName(), searchString) {
 			packageName := item.Object.GetName()
 			catalogSource := item.Object.Status.CatalogSource
-			fmt.Printf("Found package: %s in catalog source: %s matching search string: %s\n", packageName, catalogSource, searchString)
+			klog.Infof("Found package: %s in catalog source: %s matching search string: %s", packageName, catalogSource, searchString)
 
 			return packageName, catalogSource, nil
 		}
@@ -119,16 +120,16 @@ func QueryPackageManifestForAvailableChannelAndVersion(operatorName, operatorNam
 		if item.Object.GetName() == operatorName {
 			// Try the default channel first
 			defaultChannel := item.Object.Status.DefaultChannel
-			fmt.Printf("Default channel for %s: %s\n", operatorName, defaultChannel)
+			klog.Infof("Default channel for %s: %s", operatorName, defaultChannel)
 
 			for _, chanObj := range item.Object.Status.Channels {
-				fmt.Printf("Checking channel %s for %s\n", chanObj.Name, operatorName)
+				klog.Infof("Checking channel %s for %s", chanObj.Name, operatorName)
 
 				// Check if this channel has a version available
 				if chanObj.CurrentCSVDesc.Version.String() != "" {
 					channelName := chanObj.Name
 					version := chanObj.CurrentCSVDesc.Version.String()
-					fmt.Printf("Found available channel: %s with version: %s for %s\n", channelName, version, operatorName)
+					klog.Infof("Found available channel: %s with version: %s for %s", channelName, version, operatorName)
 
 					return channelName, version, nil
 				}
@@ -153,17 +154,17 @@ func QueryPackageManifestForAvailableChannelVersionAndCSV(operatorName, operator
 		if item.Object.GetName() == operatorName {
 			// Try the default channel first
 			defaultChannel := item.Object.Status.DefaultChannel
-			fmt.Printf("Default channel for %s: %s\n", operatorName, defaultChannel)
+			klog.Infof("Default channel for %s: %s", operatorName, defaultChannel)
 
 			for _, chanObj := range item.Object.Status.Channels {
-				fmt.Printf("Checking channel %s for %s\n", chanObj.Name, operatorName)
+				klog.Infof("Checking channel %s for %s", chanObj.Name, operatorName)
 
 				// Check if this channel has a version available
 				if chanObj.CurrentCSVDesc.Version.String() != "" && chanObj.CurrentCSV != "" {
 					channelName := chanObj.Name
 					version := chanObj.CurrentCSVDesc.Version.String()
 					csvName := chanObj.CurrentCSV
-					fmt.Printf("Found available channel: %s with version: %s and CSV: %s for %s\n", channelName, version, csvName, operatorName)
+					klog.Infof("Found available channel: %s with version: %s and CSV: %s for %s", channelName, version, csvName, operatorName)
 
 					return channelName, version, csvName, nil
 				}
@@ -187,7 +188,7 @@ func CheckOperatorExistsOrFail(searchString, operatorNamespace string) (string, 
 		Fail(fmt.Sprintf("Operator %s not found in cluster packagemanifests. This indicates a problem with catalog sources.", searchString))
 	}
 
-	fmt.Printf("Operator %s found as package %s in catalog source %s\n", searchString, operatorName, catalogSource)
+	klog.Infof("Operator %s found as package %s in catalog source %s", searchString, operatorName, catalogSource)
 
 	return operatorName, catalogSource
 }
@@ -206,7 +207,7 @@ func CheckOperatorChannelAndVersionOrFail(operatorName, operatorNamespace string
 			"This indicates a problem with catalog sources.", operatorName))
 	}
 
-	fmt.Printf("Operator %s has available channel %s, version %s, CSV %s\n", operatorName, channel, version, csvName)
+	klog.Infof("Operator %s has available channel %s, version %s, CSV %s", operatorName, channel, version, csvName)
 
 	return channel, version, csvName
 }

--- a/tests/globalhelper/pod.go
+++ b/tests/globalhelper/pod.go
@@ -51,7 +51,7 @@ func GetListOfPodsInNamespace(namespace string) (*corev1.PodList, error) {
 func CreateAndWaitUntilPodIsReady(pod *corev1.Pod, timeout time.Duration) error {
 	createdPod, err := GetAPIClient().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("pod %s already exists", pod.Name))
+		klog.V(5).Infof("pod %s already exists", pod.Name)
 	} else if err != nil {
 		return fmt.Errorf("failed to create pod %q (ns %s): %w", pod.Name, pod.Namespace, err)
 	}
@@ -66,8 +66,8 @@ func CreateAndWaitUntilPodIsReady(pod *corev1.Pod, timeout time.Duration) error 
 			context.TODO(), pod.Name, metav1.GetOptions{})
 
 		if err != nil {
-			klog.V(5).Info(fmt.Sprintf(
-				"Pod %s is not running, retry in 1 second", createdPod.Name))
+			klog.V(5).Infof(
+				"Pod %s is not running, retry in 1 second", createdPod.Name)
 
 			return false
 		}
@@ -78,7 +78,7 @@ func CreateAndWaitUntilPodIsReady(pod *corev1.Pod, timeout time.Duration) error 
 		}
 
 		// print the conditions
-		fmt.Printf("Pod %s conditions: %v\n", runningPod.Name, runningPod.Status.Conditions)
+		klog.Infof("Pod %s conditions: %v", runningPod.Name, runningPod.Status.Conditions)
 
 		for _, condition := range runningPod.Status.Conditions {
 			if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse && condition.Reason == "Unschedulable" {
@@ -98,8 +98,8 @@ func CreateAndWaitUntilPodIsReady(pod *corev1.Pod, timeout time.Duration) error 
 	Eventually(func() bool {
 		status, err := isPodReady(createdPod.Namespace, createdPod.Name)
 		if err != nil {
-			klog.V(5).Info(fmt.Sprintf(
-				"Pod %s is not ready, retry in 1 second", createdPod.Name))
+			klog.V(5).Infof(
+				"Pod %s is not ready, retry in 1 second", createdPod.Name)
 
 			return false
 		}

--- a/tests/globalhelper/poddisruptionbudget.go
+++ b/tests/globalhelper/poddisruptionbudget.go
@@ -30,7 +30,7 @@ func CreatePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, timeout time.D
 		pdb,
 		metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("Pod Disruption Budget %s already exists", pdb.Name))
+		klog.V(5).Infof("Pod Disruption Budget %s already exists", pdb.Name)
 	} else if err != nil {
 		return fmt.Errorf("failed to create Pod Disruption Budget %q (ns %s): %w", pdb.Name, pdb.Namespace, err)
 	}
@@ -38,8 +38,8 @@ func CreatePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, timeout time.D
 	Eventually(func() bool {
 		status, err := IsPodDisruptionBudgetCreated(poddisruptionbudget.Name, poddisruptionbudget.Namespace)
 		if err != nil {
-			klog.V(5).Info(fmt.Sprintf(
-				"Pod Disruption Budget %s is not ready, retry in 5 seconds", poddisruptionbudget.Name))
+			klog.V(5).Infof(
+				"Pod Disruption Budget %s is not ready, retry in 5 seconds", poddisruptionbudget.Name)
 
 			return false
 		}

--- a/tests/globalhelper/rbac.go
+++ b/tests/globalhelper/rbac.go
@@ -31,7 +31,7 @@ func createServiceAccount(client corev1Typed.CoreV1Interface, serviceAccountName
 		client.ServiceAccounts(namespace).Create(context.TODO(), &serviceAccount, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("serviceaccount %s already installed", serviceAccountName))
+		klog.V(5).Infof("serviceaccount %s already installed", serviceAccountName)
 
 		return nil
 	}
@@ -102,7 +102,7 @@ func createRole(client rbacv1Typed.RbacV1Interface, aRole *rbacv1.Role) error {
 		client.Roles(aRole.Namespace).Create(context.TODO(), aRole, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("role %s already installed", aRole.Name))
+		klog.V(5).Infof("role %s already installed", aRole.Name)
 
 		return nil
 	}
@@ -120,7 +120,7 @@ func deleteRole(client rbacv1Typed.RbacV1Interface, roleName, namespace string) 
 		client.Roles(namespace).Delete(context.TODO(), roleName, metav1.DeleteOptions{})
 
 	if k8serrors.IsNotFound(err) {
-		klog.V(5).Info(fmt.Sprintf("role %s does not exist", roleName))
+		klog.V(5).Infof("role %s does not exist", roleName)
 
 		return nil
 	}
@@ -138,7 +138,7 @@ func deleteRoleBinding(client rbacv1Typed.RbacV1Interface, bindingName, namespac
 		client.RoleBindings(namespace).Delete(context.TODO(), bindingName, metav1.DeleteOptions{})
 
 	if k8serrors.IsNotFound(err) {
-		klog.V(5).Info(fmt.Sprintf("rolebinding %s does not exist", bindingName))
+		klog.V(5).Infof("rolebinding %s does not exist", bindingName)
 
 		return nil
 	}
@@ -180,7 +180,7 @@ func createRoleBindingWithServiceAccountSubject(client rbacv1Typed.RbacV1Interfa
 		client.RoleBindings(namespace).Create(context.TODO(), &aRoleBinding, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("rolebinding %s already exists", bindingName))
+		klog.V(5).Infof("rolebinding %s already exists", bindingName)
 
 		return nil
 	}
@@ -196,7 +196,7 @@ func CreatePersistentVolume(persistentVolume *corev1.PersistentVolume) error {
 func createPersistentVolume(client corev1Typed.CoreV1Interface, persistentVolume *corev1.PersistentVolume) error {
 	_, err := client.PersistentVolumes().Create(context.TODO(), persistentVolume, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("persistent volume %s already created", persistentVolume.Name))
+		klog.V(5).Infof("persistent volume %s already created", persistentVolume.Name)
 	} else if err != nil {
 		return fmt.Errorf("failed to create persistent volume: %w", err)
 	}
@@ -214,7 +214,7 @@ func deletePersistentVolume(client corev1Typed.CoreV1Interface, persistentVolume
 		GracePeriodSeconds: ptr.To[int64](0),
 	})
 	if k8serrors.IsNotFound(err) {
-		klog.V(5).Info(fmt.Sprintf("persistent volume %s does not exist", persistentVolume))
+		klog.V(5).Infof("persistent volume %s does not exist", persistentVolume)
 
 		return nil
 	} else if err != nil {
@@ -239,7 +239,7 @@ func createAndWaitUntilPVCIsBound(client corev1Typed.CoreV1Interface, pvc *corev
 	timeout time.Duration, pvName string) error {
 	pvc, err := client.PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("persistent volume claim %s already created", pvc.Name))
+		klog.V(5).Infof("persistent volume claim %s already created", pvc.Name)
 	} else if err != nil {
 		return fmt.Errorf("failed to create persistent volume claim: %w", err)
 	}
@@ -247,8 +247,8 @@ func createAndWaitUntilPVCIsBound(client corev1Typed.CoreV1Interface, pvc *corev
 	Eventually(func() bool {
 		status, err := isPvcBound(client, pvc.Name, pvc.Namespace, pvName)
 		if err != nil {
-			klog.V(5).Info(fmt.Sprintf(
-				"pvc %s is not bound, retry in %d seconds", pvc.Name, retryInterval))
+			klog.V(5).Infof(
+				"pvc %s is not bound, retry in %d seconds", pvc.Name, retryInterval)
 
 			return false
 		}
@@ -277,7 +277,7 @@ func deletePersistentVolumeClaim(client corev1Typed.CoreV1Interface, pvc *corev1
 		GracePeriodSeconds: ptr.To[int64](0),
 	})
 	if k8serrors.IsNotFound(err) {
-		klog.V(5).Info(fmt.Sprintf("persistent volume claim %s does not exist", pvc.Name))
+		klog.V(5).Infof("persistent volume claim %s does not exist", pvc.Name)
 
 		return nil
 	} else if err != nil {

--- a/tests/globalhelper/replicaset.go
+++ b/tests/globalhelper/replicaset.go
@@ -17,7 +17,7 @@ func CreateAndWaitUntilReplicaSetIsReady(replicaSet *appsv1.ReplicaSet, timeout 
 	runningReplica, err := GetAPIClient().ReplicaSets(replicaSet.Namespace).Create(context.TODO(),
 		replicaSet, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("replicaSet %s already exists", replicaSet.Name))
+		klog.V(5).Infof("replicaSet %s already exists", replicaSet.Name)
 	} else if err != nil {
 		return fmt.Errorf("failed to create replicaSet %q (ns %s): %w", replicaSet.Name, replicaSet.Namespace, err)
 	}
@@ -25,8 +25,8 @@ func CreateAndWaitUntilReplicaSetIsReady(replicaSet *appsv1.ReplicaSet, timeout 
 	Eventually(func() bool {
 		status, err := isReplicaSetReady(runningReplica.Namespace, runningReplica.Name)
 		if err != nil {
-			klog.V(5).Info(fmt.Sprintf(
-				"replicaSet %s is not ready, retry in 1 second", runningReplica.Name))
+			klog.V(5).Infof(
+				"replicaSet %s is not ready, retry in 1 second", runningReplica.Name)
 
 			return false
 		}

--- a/tests/globalhelper/reporthelper.go
+++ b/tests/globalhelper/reporthelper.go
@@ -68,12 +68,12 @@ func removeContentsFromDir(dirPath, dirType string) error {
 
 	// Check if directory exists before attempting cleanup.
 	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
-		klog.V(5).Info(fmt.Sprintf("%s directory %s does not exist, skipping cleanup", dirType, dirPath))
+		klog.V(5).Infof("%s directory %s does not exist, skipping cleanup", dirType, dirPath)
 
 		return nil
 	}
 
-	klog.V(5).Info(fmt.Sprintf("removing all files from %s directory", dirPath))
+	klog.V(5).Infof("removing all files from %s directory", dirPath)
 
 	dir, err := os.Open(dirPath)
 	if err != nil {
@@ -93,9 +93,9 @@ func removeContentsFromDir(dirPath, dirType string) error {
 			return fmt.Errorf("failed to remove content from %s directory: %w", dirType, err)
 		}
 
-		klog.V(5).Info(fmt.Sprintf("file %s removed from %s directory",
+		klog.V(5).Infof("file %s removed from %s directory",
 			name,
-			dirPath))
+			dirPath)
 	}
 
 	// Delete the directory

--- a/tests/globalhelper/resourcequotas.go
+++ b/tests/globalhelper/resourcequotas.go
@@ -2,7 +2,6 @@ package globalhelper
 
 import (
 	"context"
-	"fmt"
 
 	egiClients "github.com/openshift-kni/eco-goinfra/pkg/clients"
 	corev1 "k8s.io/api/core/v1"
@@ -28,7 +27,7 @@ func createResourceQuota(client *egiClients.Settings, quota *corev1.ResourceQuot
 	_, err = client.ResourceQuotas(quota.Namespace).Create(context.TODO(), quota, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("resource quota %s already exists", quota.Name))
+		klog.V(5).Infof("resource quota %s already exists", quota.Name)
 
 		return nil
 	}

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -46,7 +46,7 @@ func executeWithRetry(cmdPath string, args []string, testCaseName string, stdout
 			cmd.Stderr = stderr
 		}
 
-		klog.V(5).Info(fmt.Sprintf("Attempt %d/%d: Running test: %s", attempt, MaxRetries, testCaseName))
+		klog.V(5).Infof("Attempt %d/%d: Running test: %s", attempt, MaxRetries, testCaseName)
 
 		err = cmd.Run()
 
@@ -59,13 +59,13 @@ func executeWithRetry(cmdPath string, args []string, testCaseName string, stdout
 
 		// Check if it was a timeout error
 		if ctx.Err() == context.DeadlineExceeded {
-			klog.V(5).Info(fmt.Sprintf("Attempt %d/%d timed out after %v for test: %s",
-				attempt, MaxRetries, TestTimeout, testCaseName))
+			klog.V(5).Infof("Attempt %d/%d timed out after %v for test: %s",
+				attempt, MaxRetries, TestTimeout, testCaseName)
 			cancel()
 
 			// If this wasn't the last attempt, continue retrying
 			if attempt < MaxRetries {
-				klog.V(5).Info(fmt.Sprintf("Retrying test: %s", testCaseName))
+				klog.V(5).Infof("Retrying test: %s", testCaseName)
 
 				continue
 			}
@@ -87,8 +87,8 @@ func launchTestsViaBinary(testCaseName string, tcNameForReport string, reportDir
 	_, err := os.Stat(fmt.Sprintf("%s/%s", GetConfiguration().General.CertsuiteRepoPath,
 		GetConfiguration().General.CertsuiteEntryPointBinary))
 	if err != nil {
-		klog.V(5).Info(fmt.Sprintf("binary does not exist: %s. "+
-			"Please run `make build-certsuite-tool` in the certsuite repo.", err))
+		klog.V(5).Infof("binary does not exist: %s. "+
+			"Please run `make build-certsuite-tool` in the certsuite repo.", err)
 
 		return fmt.Errorf("binary does not exist: %w", err)
 	}
@@ -118,7 +118,7 @@ func launchTestsViaBinary(testCaseName string, tcNameForReport string, reportDir
 	cmdPath := fmt.Sprintf("%s/%s", GetConfiguration().General.CertsuiteRepoPath,
 		GetConfiguration().General.CertsuiteEntryPointBinary)
 
-	fmt.Printf("cmd: %s %s\n", cmdPath, strings.Join(testArgs, " "))
+	klog.Infof("cmd: %s %s", cmdPath, strings.Join(testArgs, " "))
 
 	debugCertsuite, err := GetConfiguration().DebugCertsuite()
 	if err != nil {
@@ -168,7 +168,7 @@ func launchTestsViaImage(testCaseName string, tcNameForReport string, reportDir 
 	// abandoned containers. When executeWithRetry times out, the container process may continue
 	// running even after the parent process gives up, leading to resource leaks.
 	containerEngine := GetConfiguration().General.ContainerEngine
-	klog.V(5).Info(fmt.Sprintf("Selected Container engine:%s", containerEngine))
+	klog.V(5).Infof("Selected Container engine:%s", containerEngine)
 
 	certsuiteCmdArgs := []string{
 		"run",
@@ -193,7 +193,7 @@ func launchTestsViaImage(testCaseName string, tcNameForReport string, reportDir 
 	}
 
 	// print the command
-	klog.V(5).Info(fmt.Sprintf("Running command: %s %s", containerEngine, strings.Join(certsuiteCmdArgs, " ")))
+	klog.V(5).Infof("Running command: %s %s", containerEngine, strings.Join(certsuiteCmdArgs, " "))
 
 	cmd := exec.CommandContext(context.TODO(), containerEngine, certsuiteCmdArgs...)
 

--- a/tests/globalhelper/runtimeclass.go
+++ b/tests/globalhelper/runtimeclass.go
@@ -20,7 +20,7 @@ func CreateRunTimeClass(rtc *nodev1.RuntimeClass) error {
 func createRunTimeClass(client kubernetes.Interface, rtc *nodev1.RuntimeClass) error {
 	rtc, err := client.NodeV1().RuntimeClasses().Create(context.TODO(), rtc, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("runtimeclass %s already created", rtc.Name))
+		klog.V(5).Infof("runtimeclass %s already created", rtc.Name)
 	} else if err != nil {
 		return fmt.Errorf("failed to create runtimeclass %q (ns %s): %w", rtc.Name, rtc.Namespace, err)
 	}
@@ -28,7 +28,7 @@ func createRunTimeClass(client kubernetes.Interface, rtc *nodev1.RuntimeClass) e
 	Eventually(func() bool {
 		rtcCreated, err := isRtcCreated(client, rtc)
 		if err != nil {
-			klog.V(5).Info(fmt.Sprintf("rtc %s was not created, retry in %d seconds", rtc.Name, retryInterval))
+			klog.V(5).Infof("rtc %s was not created, retry in %d seconds", rtc.Name, retryInterval)
 
 			return false
 		}
@@ -61,7 +61,7 @@ func deleteRunTimeClass(client kubernetes.Interface, rtc *nodev1.RuntimeClass) e
 	Eventually(func() bool {
 		rtcDeleted, err := isRtcDeleted(client, rtc)
 		if err != nil {
-			klog.V(5).Info(fmt.Sprintf("rtc %s was not deleted, retry in %d seconds", rtc.Name, retryInterval))
+			klog.V(5).Infof("rtc %s was not deleted, retry in %d seconds", rtc.Name, retryInterval)
 
 			return false
 		}

--- a/tests/globalhelper/statefulset.go
+++ b/tests/globalhelper/statefulset.go
@@ -25,7 +25,7 @@ func createAndWaitUntilStatefulSetIsReady(client *egiClients.Settings, statefulS
 		context.TODO(), statefulSet, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("statefulSet %s already exists", statefulSet.Name))
+		klog.V(5).Infof("statefulSet %s already exists", statefulSet.Name)
 
 		return nil
 	} else if err != nil {
@@ -35,8 +35,8 @@ func createAndWaitUntilStatefulSetIsReady(client *egiClients.Settings, statefulS
 	Eventually(func() bool {
 		status, err := isStatefulSetReady(client, statefulSet.Namespace, statefulSet.Name)
 		if err != nil {
-			klog.V(5).Info(fmt.Sprintf(
-				"statefulSet %s is not ready, retry in 1 second", statefulSet.Name))
+			klog.V(5).Infof(
+				"statefulSet %s is not ready, retry in 1 second", statefulSet.Name)
 
 			return false
 		}

--- a/tests/globalhelper/storageclasses.go
+++ b/tests/globalhelper/storageclasses.go
@@ -35,7 +35,7 @@ func createStorageClass(client storagev1typed.StorageV1Interface, storageClassNa
 		&storageClassTemplate, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("storageclass %s already installed", storageClassName))
+		klog.V(5).Infof("storageclass %s already installed", storageClassName)
 
 		return nil
 	}
@@ -52,7 +52,7 @@ func deleteStorageClass(client storagev1typed.StorageV1Interface, storageClassNa
 		storageClassName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)})
 
 	if k8serrors.IsNotFound(err) {
-		klog.V(5).Info(fmt.Sprintf("storageclass %s already deleted", storageClassName))
+		klog.V(5).Infof("storageclass %s already deleted", storageClassName)
 
 		return nil
 	} else if err != nil {

--- a/tests/globalhelper/validatingwebhook.go
+++ b/tests/globalhelper/validatingwebhook.go
@@ -21,7 +21,7 @@ func deleteValidatingWebhookConfiguration(client admissionregistrationtypedv1.Ad
 		metav1.DeleteOptions{},
 	)
 	if k8serrors.IsNotFound(err) {
-		klog.V(5).Info(fmt.Sprintf("validating webhook configuration %s is not found", name))
+		klog.V(5).Infof("validating webhook configuration %s is not found", name)
 
 		return nil
 	} else if err != nil {

--- a/tests/observability/helper/helper.go
+++ b/tests/observability/helper/helper.go
@@ -96,7 +96,7 @@ func CreateAndWaitUntilCrdIsReady(crd *apiextv1.CustomResourceDefinition, timeou
 		metav1.CreateOptions{},
 	)
 	if k8serrors.IsAlreadyExists(err) {
-		klog.V(5).Info(fmt.Sprintf("crd %s already exists", crd.Name))
+		klog.V(5).Infof("crd %s already exists", crd.Name)
 
 		return nil
 	} else if err != nil {
@@ -110,8 +110,8 @@ func CreateAndWaitUntilCrdIsReady(crd *apiextv1.CustomResourceDefinition, timeou
 			metav1.GetOptions{},
 		)
 		if err != nil {
-			klog.V(5).Info(fmt.Sprintf(
-				"crd %s is not ready, retry in 5 seconds", runningCrd.Name))
+			klog.V(5).Infof(
+				"crd %s is not ready, retry in 5 seconds", runningCrd.Name)
 
 			return false
 		}

--- a/tests/operator/tests/operator_install_source.go
+++ b/tests/operator/tests/operator_install_source.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"fmt"
 
+	klog "k8s.io/klog/v2"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -71,13 +73,13 @@ var _ = Describe("Operator install-source,", Serial, Label("operator", "ocp-requ
 		channel, err := globalhelper.QueryPackageManifestForDefaultChannel(clusterLoggingOperatorName, randomNamespace)
 		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+clusterLoggingOperatorName)
 
-		fmt.Printf("CHANNEL FOUND: %s\n", channel)
+		klog.Infof("CHANNEL FOUND: %s", channel)
 
 		By("Query the packagemanifest for the " + clusterLoggingOperatorName)
 		version, err := globalhelper.QueryPackageManifestForVersion(clusterLoggingOperatorName, randomNamespace, channel)
 		Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+clusterLoggingOperatorName)
 
-		fmt.Printf("VERSION FOUND: %s\n", version)
+		klog.Infof("VERSION FOUND: %s", version)
 
 		By("Deploy cluster-logging operator for testing")
 		err = tshelper.DeployOperatorSubscription(

--- a/tests/operator/tests/operator_install_status.go
+++ b/tests/operator/tests/operator_install_status.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"fmt"
 
+	klog "k8s.io/klog/v2"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -148,12 +150,12 @@ var _ = Describe("Operator install-status,", Serial, Label("operator", "ocp-requ
 		Eventually(func() bool {
 			isNotSucceeded, err := tshelper.IsCSVNotSucceeded(lightweightOp.CSVPrefix, randomNamespace)
 			if err != nil {
-				fmt.Printf("Error checking CSV status for %s: %v\n", lightweightOp.CSVPrefix, err)
+				klog.Infof("Error checking CSV status for %s: %v", lightweightOp.CSVPrefix, err)
 
 				return false
 			}
 
-			fmt.Printf("%s operator %s CSV status is not Succeeded: %t\n", lightweightOp.PackageName, lightweightOp.CSVPrefix, isNotSucceeded)
+			klog.Infof("%s operator %s CSV status is not Succeeded: %t", lightweightOp.PackageName, lightweightOp.CSVPrefix, isNotSucceeded)
 
 			return isNotSucceeded
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Equal(true),
@@ -256,12 +258,12 @@ var _ = Describe("Operator install-status,", Serial, Label("operator", "ocp-requ
 		Eventually(func() bool {
 			isNotSucceeded, err := tshelper.IsCSVNotSucceeded(lightweightOp.CSVPrefix, randomNamespace)
 			if err != nil {
-				fmt.Printf("Error checking CSV status for %s: %v\n", lightweightOp.CSVPrefix, err)
+				klog.Infof("Error checking CSV status for %s: %v", lightweightOp.CSVPrefix, err)
 
 				return false
 			}
 
-			fmt.Printf("%s operator %s CSV status is not Succeeded: %t\n", lightweightOp.PackageName, lightweightOp.CSVPrefix, isNotSucceeded)
+			klog.Infof("%s operator %s CSV status is not Succeeded: %t", lightweightOp.PackageName, lightweightOp.CSVPrefix, isNotSucceeded)
 
 			return isNotSucceeded
 		}, tsparams.TimeoutLabelCsv, tsparams.PollingInterval).Should(Equal(true),

--- a/tests/operator/tests/operator_single_or_multi_namespaced_allowed_in_tenant_namespaces.go
+++ b/tests/operator/tests/operator_single_or_multi_namespaced_allowed_in_tenant_namespaces.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"fmt"
 
+	klog "k8s.io/klog/v2"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -356,13 +358,13 @@ func installClusterWideOperator() {
 	channel, err := globalhelper.QueryPackageManifestForDefaultChannel(clusterLoggingOperatorName, openshiftLoggingNamespace)
 	Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+clusterLoggingOperatorName)
 
-	fmt.Printf("CHANNEL FOUND: %s\n", channel)
+	klog.Infof("CHANNEL FOUND: %s", channel)
 
 	By("Query the packagemanifest for the " + clusterLoggingOperatorName)
 	version, err := globalhelper.QueryPackageManifestForVersion(clusterLoggingOperatorName, openshiftLoggingNamespace, channel)
 	Expect(err).ToNot(HaveOccurred(), "Error querying package manifest for "+clusterLoggingOperatorName)
 
-	fmt.Printf("VERSION FOUND: %s\n", version)
+	klog.Infof("VERSION FOUND: %s", version)
 
 	By("Deploy cluster-logging operator for testing")
 	err = tshelper.DeployOperatorSubscription(

--- a/tests/performance/helper/helper.go
+++ b/tests/performance/helper/helper.go
@@ -173,7 +173,7 @@ func ConfigurePrivilegedServiceAccount(namespace string) error {
 	_, err := globalhelper.GetAPIClient().RbacV1Interface.Roles(namespace).Create(context.TODO(), &aRole, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
 		// role already exists
-		klog.V(5).Info(fmt.Sprintf("role %s already exists", aRole.Name))
+		klog.V(5).Infof("role %s already exists", aRole.Name)
 	} else if err != nil {
 		return fmt.Errorf("error creating role, err=%w", err)
 	}
@@ -183,7 +183,7 @@ func ConfigurePrivilegedServiceAccount(namespace string) error {
 	_, err = globalhelper.GetAPIClient().RbacV1Interface.RoleBindings(namespace).Create(context.TODO(), &aRoleBinding, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
 		// rolebinding already exists
-		klog.V(5).Info(fmt.Sprintf("rolebinding %s already exists", aRoleBinding.Name))
+		klog.V(5).Infof("rolebinding %s already exists", aRoleBinding.Name)
 	} else if err != nil {
 		return fmt.Errorf("error creating rolebinding, err=%w", err)
 	}
@@ -193,7 +193,7 @@ func ConfigurePrivilegedServiceAccount(namespace string) error {
 		&aServiceAccount, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
 		// service account already exists
-		klog.V(5).Info(fmt.Sprintf("service account %s already exists", aServiceAccount.Name))
+		klog.V(5).Infof("service account %s already exists", aServiceAccount.Name)
 	} else if err != nil {
 		return fmt.Errorf("error creating service account, err=%w", err)
 	}

--- a/tests/platformalteration/tests/platform_alteration_ocp_lifecycle.go
+++ b/tests/platformalteration/tests/platform_alteration_ocp_lifecycle.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	klog "k8s.io/klog/v2"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -157,7 +159,7 @@ func verifyRHCOSVersions(nodes []corev1.Node, rhcosVersionMapContent string) err
 				rhcosVersion, node.Name)
 		}
 
-		fmt.Printf("✓ Node %s RHCOS version %s found in rhcos_version_map\n", node.Name, rhcosVersion)
+		klog.Infof("✓ Node %s RHCOS version %s found in rhcos_version_map", node.Name, rhcosVersion)
 	}
 
 	return nil

--- a/tests/utils/cluster/cluster.go
+++ b/tests/utils/cluster/cluster.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 
 	klog "k8s.io/klog/v2"
 
@@ -20,7 +19,7 @@ func IsClusterStable(client corev1Typed.NodeInterface) (bool, error) {
 
 	for _, node := range nodes.Items {
 		if node.Spec.Unschedulable {
-			klog.V(5).Info(fmt.Sprintf("node %s is in unschedulable state, trying to uncordon it", node.Name))
+			klog.V(5).Infof("node %s is in unschedulable state, trying to uncordon it", node.Name)
 			err := nodesutils.UnCordon(client, node.Name)
 
 			if err != nil {
@@ -36,7 +35,7 @@ func IsClusterStable(client corev1Typed.NodeInterface) (bool, error) {
 				return false, nil
 			}
 
-			klog.V(5).Info(fmt.Sprintf("node %s is in schedulable state", node.Name))
+			klog.V(5).Infof("node %s is in schedulable state", node.Name)
 		}
 	}
 

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -229,7 +229,7 @@ func deployCertsuiteDir(confFileName string, dirName string, yamlTag string, env
 				"%s env var is set", dirName, yamlTag, envVar, confFileName)
 	}
 
-	klog.V(4).Info(fmt.Sprintf("%s directory is not present. Creating directory", dirName))
+	klog.V(4).Infof("%s directory is not present. Creating directory", dirName)
 
 	err = os.MkdirAll(dirName, globalparameters.DirPermissions)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Replace 58 `klog.Info(fmt.Sprintf(...))` calls with `klog.Infof(...)` — removes redundant double-formatting
- Replace 24 `fmt.Printf`/`fmt.Println` calls with `klog.Infof` — enables structured logging and log-level control
- Remove unused `fmt` imports from 2 files where it was only used for the replaced patterns
- 26 files changed across globalhelper, operator tests, platform alteration tests, and cluster utils

## Test plan

- [ ] make lint passes
- [ ] make test passes (pre-existing TestDebugCertsuite failure is unrelated)