### PR TITLE
fix: use comma-ok idiom in IsCRCCluster to prevent false positives

### DIFF
--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -440,20 +440,17 @@ func IsCRCCluster() bool {
 		}
 	}
 
-	// Method 3: Check for CRC-specific labels or annotations
-	for _, node := range nodes.Items {
-		if labels := node.Labels; labels != nil {
-			// CRC clusters set these role labels with empty values.
-			// Use the comma-ok idiom to distinguish "present with empty value"
-			// from "absent" — a plain map lookup returns "" for both cases.
-			_, hasMaster := labels["node-role.kubernetes.io/master"]
-			_, hasControlPlane := labels["node-role.kubernetes.io/control-plane"]
+	// Method 3: A single node carrying both master and control-plane role
+	// labels is a strong CRC signal. Use the comma-ok idiom because CRC sets
+	// these labels with empty values, and a plain map lookup returns "" for
+	// both "present but empty" and "absent".
+	if len(nodes.Items) == 1 {
+		labels := nodes.Items[0].Labels
+		_, hasMaster := labels["node-role.kubernetes.io/master"]
+		_, hasControlPlane := labels["node-role.kubernetes.io/control-plane"]
 
-			if hasMaster && hasControlPlane {
-				if len(nodes.Items) == 1 { // Single node with both roles suggests CRC
-					return true
-				}
-			}
+		if hasMaster && hasControlPlane {
+			return true
 		}
 	}
 

--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -443,9 +443,14 @@ func IsCRCCluster() bool {
 	// Method 3: Check for CRC-specific labels or annotations
 	for _, node := range nodes.Items {
 		if labels := node.Labels; labels != nil {
-			// CRC clusters often have specific labels
-			if labels["node-role.kubernetes.io/master"] == "" && labels["node-role.kubernetes.io/control-plane"] == "" {
-				if len(nodes.Items) == 1 { // Single node with master role suggests CRC
+			// CRC clusters set these role labels with empty values.
+			// Use the comma-ok idiom to distinguish "present with empty value"
+			// from "absent" — a plain map lookup returns "" for both cases.
+			_, hasMaster := labels["node-role.kubernetes.io/master"]
+			_, hasControlPlane := labels["node-role.kubernetes.io/control-plane"]
+
+			if hasMaster && hasControlPlane {
+				if len(nodes.Items) == 1 { // Single node with both roles suggests CRC
 					return true
 				}
 			}


### PR DESCRIPTION
## Summary
- `IsCRCCluster()` checked `labels["node-role.kubernetes.io/master"] == ""` which is true when the key is absent (Go zero value), falsely matching any single-node cluster (SNO, Kind, etc.)
- Replaced with comma-ok idiom to correctly distinguish "label present with empty value" from "label absent"
- Simplified Method 3: removed redundant `for` loop over nodes (body only matched when `len == 1`, so the loop was always a no-op on multi-node clusters) and unnecessary nil guard on labels

## Test plan
- [ ] Verify IsCRCCluster returns false on single-node non-CRC clusters
- [ ] Verify IsCRCCluster returns true on actual CRC clusters
- [ ] `make lint` passes