### PR TITLE
fix: remove os.Chdir side effect in makeDockerConfig

### DIFF
--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -251,6 +251,7 @@ func (c *Config) makeDockerConfig() error {
 	if err != nil {
 		return fmt.Errorf("failed to create docker config file: %w", err)
 	}
+	defer configFile.Close()
 
 	_, err = configFile.Write([]byte("{ \"auths\": {} }"))
 	if err != nil {

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -247,12 +247,7 @@ func (c *Config) makeDockerConfig() error {
 		return fmt.Errorf("failed to create dir %v: %w", c.General.DockerConfigDir, err)
 	}
 
-	err = os.Chdir(c.General.DockerConfigDir)
-	if err != nil {
-		return fmt.Errorf("failed to change dir to %v: %w", c.General.DockerConfigDir, err)
-	}
-
-	configFile, err = os.Create("config")
+	configFile, err = os.Create(filepath.Join(c.General.DockerConfigDir, "config"))
 	if err != nil {
 		return fmt.Errorf("failed to create docker config file: %w", err)
 	}


### PR DESCRIPTION
## Summary
- `makeDockerConfig()` called `os.Chdir()` during config init, permanently changing the process working directory for all subsequent operations
- Replaced with `filepath.Join` to construct the absolute path for the config file
- Added `defer configFile.Close()` to fix a leaked file descriptor in the same function

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Verify docker config file is created at the correct path