### PR TITLE
fix: correct container engine env var name in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ var _ = Describe("Feature", func() {
 - `USE_BINARY` - Use local binary instead of container
 - `DISABLE_INTRUSIVE_TESTS` - Skip intrusive tests
 - `NON_LINUX_ENV` - Set to any value (including empty string) for macOS development
-- `CERTSUITE_CONTAINER_CLIENT` - Container runtime (`docker` or `podman`)
+- `CONTAINER_ENGINE` - Container runtime (`docker` or `podman`)
 - `DOCKER_CONFIG_DIR` - Docker config directory (macOS: `$HOME/.docker`)
 
 ### Key Dependencies

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following environment variables are used to configure the test setup.
 | ENABLE_PARALLEL | Enable ginkgo -p parallel flags (experimental). Default is `false`. |
 | FORCE_DOWNLOAD_UNSTABLE | Force download the unstable image. Default is `false`. |
 | NON_LINUX_ENV | Allow the test suites to run in a non Linux environment. Default is `false`. |
+| CONTAINER_ENGINE | Container runtime to use (`docker` or `podman`). Default is `docker`. |
 
 ## Steps to run the tests
 
@@ -75,7 +76,7 @@ Make sure [docker](https://www.docker.com/) or [podman](https://podman.io/) is r
 Set your local container runtime to your environment with:
 
 ```sh
-export CERTSUITE_CONTAINER_CLIENT=docker
+export CONTAINER_ENGINE=docker
 ```
 
 #### Clone the repo and change directory to the cloned repo


### PR DESCRIPTION
## Summary
- README and AGENTS.md reference `CERTSUITE_CONTAINER_CLIENT` but the config struct reads `CONTAINER_ENGINE` via envconfig tag
- Updated all doc references to use the correct env var name
- Added `CONTAINER_ENGINE` to the README env var table

## Test plan
- [ ] Verify `CONTAINER_ENGINE=podman` is respected when running tests
- [ ] Confirm no other references to the old env var name exist