### PR TITLE
fix: eliminate data race in GenerateRandomString by using global rand

### DIFF
--- a/tests/globalhelper/helper.go
+++ b/tests/globalhelper/helper.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path"
 	"strings"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -381,9 +380,6 @@ func CopyFiles(src string, dst string) error {
 	return nil
 }
 
-var seededRand *rand.Rand = rand.New(
-	rand.NewSource(time.Now().UnixNano()))
-
 func GenerateRandomString(length int) string {
 	charset := "abcdefghijklmnopqrstuvwxyz"
 
@@ -391,7 +387,7 @@ func GenerateRandomString(length int) string {
 	b := make([]byte, length)
 
 	for i := range b {
-		b[i] = charset[seededRand.Intn(len(charset))]
+		b[i] = charset[rand.Intn(len(charset))]
 	}
 
 	return string(b)


### PR DESCRIPTION
## Summary
- Removed package-level `rand.New(rand.NewSource(time.Now().UnixNano()))` which was deprecated and unsafe for concurrent access
- Replaced with global `rand.Intn()` which is concurrency-safe and auto-seeded since Go 1.20
- Removed unused `time` import

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Run tests with `-race` flag to confirm no data races