### PR TITLE
fix: add preflight suite name and replace panic with error in getTestSuiteName

### DIFF
--- a/tests/globalhelper/reporthelper.go
+++ b/tests/globalhelper/reporthelper.go
@@ -175,7 +175,15 @@ func formatTestCaseName(tcName string) string {
 
 func CopyClaimFileToTcFolder(tcName, formattedTcName, reportDir string) {
 	srcClaim := path.Join(reportDir, globalparameters.DefaultClaimFileName)
-	dstDir := path.Join(GetConfiguration().General.ReportDirAbsPath, "Debug", getTestSuiteName(tcName), formattedTcName)
+
+	suiteName, suiteErr := getTestSuiteName(tcName)
+	if suiteErr != nil {
+		klog.ErrorS(suiteErr, "could not determine test suite name", "testCase", tcName)
+
+		return
+	}
+
+	dstDir := path.Join(GetConfiguration().General.ReportDirAbsPath, "Debug", suiteName, formattedTcName)
 	dstClaim := path.Join(dstDir, globalparameters.DefaultClaimFileName)
 
 	_, err := os.Stat(srcClaim)

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -130,7 +130,7 @@ func launchTestsViaBinary(testCaseName string, tcNameForReport string, reportDir
 	if debugCertsuite {
 		suiteName, suiteErr := getTestSuiteName(testCaseName)
 		if suiteErr != nil {
-			return suiteErr
+			return fmt.Errorf("failed to create debug log file: %w", suiteErr)
 		}
 
 		outfile = GetConfiguration().CreateLogFile(suiteName, tcNameForReport)
@@ -211,7 +211,7 @@ func launchTestsViaImage(testCaseName string, tcNameForReport string, reportDir 
 	if debugCertsuite {
 		suiteName, suiteErr := getTestSuiteName(testCaseName)
 		if suiteErr != nil {
-			return suiteErr
+			return fmt.Errorf("failed to create debug log file: %w", suiteErr)
 		}
 
 		outfile := GetConfiguration().CreateLogFile(suiteName, tcNameForReport)
@@ -267,45 +267,26 @@ func LaunchTests(testCaseName string, tcNameForReport string, reportDir string, 
 	return launchTestsViaImage(testCaseName, tcNameForReport, reportDir, configDir)
 }
 
+// suiteNames lists every known suite name for getTestSuiteName lookups.
+// Add new suites here instead of extending an if/else chain.
+var suiteNames = []string{
+	globalparameters.NetworkSuiteName,
+	globalparameters.AffiliatedCertificationSuiteName,
+	globalparameters.LifecycleSuiteName,
+	globalparameters.PlatformAlterationSuiteName,
+	globalparameters.ObservabilitySuiteName,
+	globalparameters.AccessControlSuiteName,
+	globalparameters.PerformanceSuiteName,
+	globalparameters.ManageabilitySuiteName,
+	globalparameters.OperatorSuiteName,
+	globalparameters.PreflightSuiteName,
+}
+
 func getTestSuiteName(testCaseName string) (string, error) {
-	if strings.Contains(testCaseName, globalparameters.NetworkSuiteName) {
-		return globalparameters.NetworkSuiteName, nil
-	}
-
-	if strings.Contains(testCaseName, globalparameters.AffiliatedCertificationSuiteName) {
-		return globalparameters.AffiliatedCertificationSuiteName, nil
-	}
-
-	if strings.Contains(testCaseName, globalparameters.LifecycleSuiteName) {
-		return globalparameters.LifecycleSuiteName, nil
-	}
-
-	if strings.Contains(testCaseName, globalparameters.PlatformAlterationSuiteName) {
-		return globalparameters.PlatformAlterationSuiteName, nil
-	}
-
-	if strings.Contains(testCaseName, globalparameters.ObservabilitySuiteName) {
-		return globalparameters.ObservabilitySuiteName, nil
-	}
-
-	if strings.Contains(testCaseName, globalparameters.AccessControlSuiteName) {
-		return globalparameters.AccessControlSuiteName, nil
-	}
-
-	if strings.Contains(testCaseName, globalparameters.PerformanceSuiteName) {
-		return globalparameters.PerformanceSuiteName, nil
-	}
-
-	if strings.Contains(testCaseName, globalparameters.ManageabilitySuiteName) {
-		return globalparameters.ManageabilitySuiteName, nil
-	}
-
-	if strings.Contains(testCaseName, globalparameters.OperatorSuiteName) {
-		return globalparameters.OperatorSuiteName, nil
-	}
-
-	if strings.Contains(testCaseName, globalparameters.PreflightSuiteName) {
-		return globalparameters.PreflightSuiteName, nil
+	for _, name := range suiteNames {
+		if strings.Contains(testCaseName, name) {
+			return name, nil
+		}
 	}
 
 	return "", fmt.Errorf("unable to retrieve test suite name from test case name %s", testCaseName)

--- a/tests/globalhelper/runhelper.go
+++ b/tests/globalhelper/runhelper.go
@@ -126,8 +126,14 @@ func launchTestsViaBinary(testCaseName string, tcNameForReport string, reportDir
 	}
 
 	var outfile *os.File
+
 	if debugCertsuite {
-		outfile = GetConfiguration().CreateLogFile(getTestSuiteName(testCaseName), tcNameForReport)
+		suiteName, suiteErr := getTestSuiteName(testCaseName)
+		if suiteErr != nil {
+			return suiteErr
+		}
+
+		outfile = GetConfiguration().CreateLogFile(suiteName, tcNameForReport)
 
 		defer outfile.Close()
 
@@ -203,7 +209,12 @@ func launchTestsViaImage(testCaseName string, tcNameForReport string, reportDir 
 	}
 
 	if debugCertsuite {
-		outfile := GetConfiguration().CreateLogFile(getTestSuiteName(testCaseName), tcNameForReport)
+		suiteName, suiteErr := getTestSuiteName(testCaseName)
+		if suiteErr != nil {
+			return suiteErr
+		}
+
+		outfile := GetConfiguration().CreateLogFile(suiteName, tcNameForReport)
 
 		defer outfile.Close()
 
@@ -256,42 +267,46 @@ func LaunchTests(testCaseName string, tcNameForReport string, reportDir string, 
 	return launchTestsViaImage(testCaseName, tcNameForReport, reportDir, configDir)
 }
 
-func getTestSuiteName(testCaseName string) string {
+func getTestSuiteName(testCaseName string) (string, error) {
 	if strings.Contains(testCaseName, globalparameters.NetworkSuiteName) {
-		return globalparameters.NetworkSuiteName
+		return globalparameters.NetworkSuiteName, nil
 	}
 
 	if strings.Contains(testCaseName, globalparameters.AffiliatedCertificationSuiteName) {
-		return globalparameters.AffiliatedCertificationSuiteName
+		return globalparameters.AffiliatedCertificationSuiteName, nil
 	}
 
 	if strings.Contains(testCaseName, globalparameters.LifecycleSuiteName) {
-		return globalparameters.LifecycleSuiteName
+		return globalparameters.LifecycleSuiteName, nil
 	}
 
 	if strings.Contains(testCaseName, globalparameters.PlatformAlterationSuiteName) {
-		return globalparameters.PlatformAlterationSuiteName
+		return globalparameters.PlatformAlterationSuiteName, nil
 	}
 
 	if strings.Contains(testCaseName, globalparameters.ObservabilitySuiteName) {
-		return globalparameters.ObservabilitySuiteName
+		return globalparameters.ObservabilitySuiteName, nil
 	}
 
 	if strings.Contains(testCaseName, globalparameters.AccessControlSuiteName) {
-		return globalparameters.AccessControlSuiteName
+		return globalparameters.AccessControlSuiteName, nil
 	}
 
 	if strings.Contains(testCaseName, globalparameters.PerformanceSuiteName) {
-		return globalparameters.PerformanceSuiteName
+		return globalparameters.PerformanceSuiteName, nil
 	}
 
 	if strings.Contains(testCaseName, globalparameters.ManageabilitySuiteName) {
-		return globalparameters.ManageabilitySuiteName
+		return globalparameters.ManageabilitySuiteName, nil
 	}
 
 	if strings.Contains(testCaseName, globalparameters.OperatorSuiteName) {
-		return globalparameters.OperatorSuiteName
+		return globalparameters.OperatorSuiteName, nil
 	}
 
-	panic(fmt.Sprintf("unable to retrieve test suite name from test case name %s", testCaseName))
+	if strings.Contains(testCaseName, globalparameters.PreflightSuiteName) {
+		return globalparameters.PreflightSuiteName, nil
+	}
+
+	return "", fmt.Errorf("unable to retrieve test suite name from test case name %s", testCaseName)
 }

--- a/tests/globalparameters/globalparameters.go
+++ b/tests/globalparameters/globalparameters.go
@@ -111,4 +111,5 @@ var (
 	PerformanceSuiteName             = "performance"
 	ManageabilitySuiteName           = "manageability"
 	OperatorSuiteName                = "operator"
+	PreflightSuiteName               = "preflight"
 )


### PR DESCRIPTION
## Summary
- Added `PreflightSuiteName` constant to globalparameters
- Changed `getTestSuiteName` from panicking on unknown input to returning an error
- Replaced the 10-branch if/else chain with a data-driven slice lookup for cleaner maintenance
- Wrapped bare `suiteErr` returns in `launchTestsViaBinary` and `launchTestsViaImage` with `fmt.Errorf` context
- Updated all 3 callers (2 in runhelper.go, 1 in reporthelper.go) to handle the error

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Run preflight tests with `DEBUG_CERTSUITE=true` — should no longer panic
- [ ] Verify unknown suite names produce an error instead of a panic