### PR TITLE
fix: update DefaultJunitReportName to match upstream certsuite

### DIFF
--- a/tests/globalparameters/globalparameters.go
+++ b/tests/globalparameters/globalparameters.go
@@ -97,7 +97,7 @@ type (
 var (
 	DefaultClaimFileName             = "claim.json"
 	DefaultCertsuiteConfigFileName   = "certsuite_config.yml"
-	DefaultJunitReportName           = "cnf-certification-tests_junit.xml"
+	DefaultJunitReportName           = "certsuite-tests_junit.xml"
 	PartnerNamespaceEnvVarName       = "CERTSUITE_PARTNER_NAMESPACE"
 	TestCasePassed                   = "passed"
 	TestCaseFailed                   = "failed"


### PR DESCRIPTION
## Summary
- Updated `DefaultJunitReportName` from `cnf-certification-tests_junit.xml` to `certsuite-tests_junit.xml` to match the upstream certsuite rename
- Confirmed upstream uses `certsuite-tests_junit.xml` in `pkg/certsuite/certsuite.go`

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Verify JUnit report is found correctly after a certsuite run