### PR TITLE
docs: remove phantom preflight feature, update Makefile targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@ The project uses Ginkgo/Gomega BDD testing framework. Tests deploy resources to 
 
 ## Commands
 
+### Getting Help
+```bash
+make                      # Show available targets with descriptions (default)
+make help                 # Same as above
+```
+
 ### Installation and Setup
 ```bash
 make install              # Install all dependencies (runs deps-update + install-ginkgo)
@@ -50,6 +56,11 @@ make lint                 # Run golangci-lint and shfmt
 make gofmt                # Check Go code formatting
 make fmt                  # Format Go code
 make vet                  # Run go vet
+```
+
+### Utilities
+```bash
+make download-unstable    # Download unstable certsuite image for testing
 ```
 
 ## Architecture
@@ -160,7 +171,6 @@ Available test features (set via `FEATURES` env var):
 - `operator` - Operator installation and status
 - `performance` - CPU pinning and scheduling
 - `platformalteration` - Node and kernel configuration
-- `preflight` - Red Hat preflight certification checks
 
 ### Go Version
 This project uses Go 1.26.1.

--- a/tests/accesscontrol/parameters/parameters.go
+++ b/tests/accesscontrol/parameters/parameters.go
@@ -74,6 +74,7 @@ const (
 	TestCaseNameAccessControlPodHostPath            = "access-control-pod-host-path"
 	CertsuiteSecurityContextTcName                  = "access-control-security-context"
 	TestCaseNameAccessControlOneProcessPerContainer = "access-control-one-process-per-container"
+	TestCaseNameAccessControlReadOnlyRootFileSystem = "access-control-security-context-read-only-root-file-system"
 
 	TestAccessControlNameSpace = "accesscontrol-tests"
 

--- a/tests/accesscontrol/tests/access_control_security_context_read_only_root_file_system.go
+++ b/tests/accesscontrol/tests/access_control_security_context_read_only_root_file_system.go
@@ -1,0 +1,149 @@
+package accesscontrol
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tshelper "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/accesscontrol/helper"
+	tsparams "github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/accesscontrol/parameters"
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalhelper"
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/globalparameters"
+	"github.com/redhat-best-practices-for-k8s/certsuite-qe/tests/utils/deployment"
+)
+
+var _ = Describe("Access-control security-context-read-only-root-file-system,", Label("accesscontrol-readonly-root-fs"), func() {
+	var (
+		randomNamespace          string
+		randomReportDir          string
+		randomCertsuiteConfigDir string
+	)
+
+	BeforeEach(func() {
+		// Create random namespace and keep original report and certsuite config directories
+		randomNamespace, randomReportDir, randomCertsuiteConfigDir =
+			globalhelper.BeforeEachSetupWithRandomPrivilegedNamespace(
+				tsparams.TestAccessControlNameSpace)
+
+		By("Define certsuite config file")
+		err := globalhelper.DefineCertsuiteConfig(
+			[]string{randomNamespace},
+			[]string{tsparams.TestPodLabel},
+			[]string{},
+			[]string{},
+			[]string{}, randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred(), "error defining certsuite config file")
+	})
+
+	AfterEach(func() {
+		globalhelper.AfterEachCleanupWithRandomNamespace(randomNamespace,
+			randomReportDir, randomCertsuiteConfigDir, tsparams.Timeout)
+	})
+
+	It("one deployment, one pod, one container with read-only root filesystem", func() {
+		By("Define deployment with read-only root filesystem")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		deployment.RedefineWithReadOnlyRootFilesystem(dep, true)
+
+		By("Create deployment")
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment has read-only root filesystem enabled")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).ToNot(BeNil())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			tsparams.TestCaseNameAccessControlReadOnlyRootFileSystem,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Claim report")
+		err = globalhelper.ValidateIfReportsAreValid(
+			tsparams.TestCaseNameAccessControlReadOnlyRootFileSystem,
+			globalparameters.TestCasePassed, randomReportDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("one deployment, one pod, one container without read-only root filesystem [negative]", func() {
+		By("Define deployment without read-only root filesystem")
+		dep, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		deployment.RedefineWithReadOnlyRootFilesystem(dep, false)
+
+		By("Create deployment")
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep, tsparams.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment does not have read-only root filesystem enabled")
+		runningDeployment, err := globalhelper.GetRunningDeployment(dep.Namespace, dep.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext).ToNot(BeNil())
+		Expect(runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem).ToNot(BeNil())
+		Expect(*runningDeployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem).To(BeFalse())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			tsparams.TestCaseNameAccessControlReadOnlyRootFileSystem,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Claim report")
+		err = globalhelper.ValidateIfReportsAreValid(
+			tsparams.TestCaseNameAccessControlReadOnlyRootFileSystem,
+			globalparameters.TestCaseFailed, randomReportDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("two deployments, one with and one without read-only root filesystem [negative]", func() {
+		By("Define deployment with read-only root filesystem")
+		dep1, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment1", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		deployment.RedefineWithReadOnlyRootFilesystem(dep1, true)
+
+		By("Create deployment 1")
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep1, tsparams.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment1 has read-only root filesystem enabled")
+		runningDeployment1, err := globalhelper.GetRunningDeployment(dep1.Namespace, dep1.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment1.Spec.Template.Spec.Containers[0].SecurityContext).ToNot(BeNil())
+		Expect(*runningDeployment1.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
+
+		By("Define deployment without read-only root filesystem")
+		dep2, err := tshelper.DefineDeployment(1, 1, "accesscontroldeployment2", randomNamespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		deployment.RedefineWithReadOnlyRootFilesystem(dep2, false)
+
+		By("Create deployment 2")
+		err = globalhelper.CreateAndWaitUntilDeploymentIsReady(dep2, tsparams.Timeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Assert that deployment2 does not have read-only root filesystem enabled")
+		runningDeployment2, err := globalhelper.GetRunningDeployment(dep2.Namespace, dep2.Name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runningDeployment2.Spec.Template.Spec.Containers[0].SecurityContext).ToNot(BeNil())
+		Expect(*runningDeployment2.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem).To(BeFalse())
+
+		By("Start test")
+		err = globalhelper.LaunchTests(
+			tsparams.TestCaseNameAccessControlReadOnlyRootFileSystem,
+			globalhelper.ConvertSpecNameToFileName(CurrentSpecReport().FullText()), randomReportDir, randomCertsuiteConfigDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verify test case status in Claim report")
+		err = globalhelper.ValidateIfReportsAreValid(
+			tsparams.TestCaseNameAccessControlReadOnlyRootFileSystem,
+			globalparameters.TestCaseFailed, randomReportDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/tests/utils/deployment/deployment.go
+++ b/tests/utils/deployment/deployment.go
@@ -587,6 +587,15 @@ func RedefineWithContainersSecurityContextAllowPrivilegeEscalation(deployment *a
 	}
 }
 
+// RedefineWithReadOnlyRootFilesystem redefines deployment with readOnlyRootFilesystem set to the specified value.
+func RedefineWithReadOnlyRootFilesystem(deployment *appsv1.Deployment, readOnly bool) {
+	for index := range deployment.Spec.Template.Spec.Containers {
+		deployment.Spec.Template.Spec.Containers[index].SecurityContext = &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: &readOnly,
+		}
+	}
+}
+
 func RedefineContainerCommand(deployment *appsv1.Deployment, index int, command []string) error {
 	if len(deployment.Spec.Template.Spec.Containers) > index {
 		deployment.Spec.Template.Spec.Containers[index].Command = command


### PR DESCRIPTION
## Summary

- Remove `preflight` from the test features list in AGENTS.md -- the `tests/preflight/` directory does not exist
- Add missing `help` target (now the default when running `make` with no arguments)
- Add missing `download-unstable` utility target

## Test plan

- [ ] Verify listed test features match directories under `tests/`
- [ ] Verify documented Makefile targets match actual `Makefile`