### PR TITLE
fix: use ubi-minimal for platformalteration tests

### DIFF
--- a/tests/platformalteration/parameters/parameters.go
+++ b/tests/platformalteration/parameters/parameters.go
@@ -57,7 +57,7 @@ const (
 	FindHugePagesFiles    = "find /host/sys/devices/system/node/ -name nr_hugepages"
 	PerformanceProfileCrd = "performanceprofiles.performance.openshift.io"
 
-	SampleWorkloadImage = globalparameters.UBIMicroImage
+	SampleWorkloadImage = "registry.access.redhat.com/ubi9/ubi-minimal:latest"
 
 	IstioVersion = "1.30.2"
 )


### PR DESCRIPTION
## Summary

- The platformalteration tests exec commands (`find`, `chroot`, `cat`, `echo`, `touch`, `getenforce`) inside DaemonSet pods using `SampleWorkloadImage`
- The previous image (`ubi8/ubi-micro`) does not include `find` or other standard utilities, causing the `platform-alteration-hugepages-config` test to consistently fail with exit code 127 ("command not found") on every nightly run
- Switch to `ubi9/ubi-minimal` which includes bash, find, and all other utilities these tests require
- Only changes the platformalteration suite's `SampleWorkloadImage` — other suites that don't exec into pods continue using ubi-micro

## Test plan

- [ ] Re-run `QE OCP 4.14 Testing` and `QE OCP 4.16 Testing` workflows via workflow_dispatch after merge
- [ ] Verify `platformalteration3-ocp` job passes (specifically the hugepages-config test)
- [ ] Monitor nightlies for 2-3 days to confirm stability