### PR TITLE
fix: use ubi9/ubi-minimal for platformalteration tests

### DIFF
--- a/tests/platformalteration/parameters/parameters.go
+++ b/tests/platformalteration/parameters/parameters.go
@@ -57,7 +57,7 @@ const (
 	FindHugePagesFiles    = "find /host/sys/devices/system/node/ -name nr_hugepages"
 	PerformanceProfileCrd = "performanceprofiles.performance.openshift.io"
 
-	SampleWorkloadImage = globalparameters.UBIMicroImage
+	SampleWorkloadImage = "registry.access.redhat.com/ubi9/ubi-minimal:latest"
 
 	IstioVersion = "1.30.3"
 )


### PR DESCRIPTION
## Summary
- Replace `globalparameters.UBIMicroImage` (ubi8/ubi-micro) with `ubi9/ubi-minimal:latest` for the platformalteration `SampleWorkloadImage`
- ubi8/ubi-micro does not include `find`, `cat`, `chroot`, or other utilities that platformalteration tests exec into DaemonSet pods
- This has been causing consistent hugepages test failures (exit code 127) in OCP 4.14 and 4.16 nightlies

## Test plan
- [ ] OCP nightly runs for platformalteration3 suite should pass (hugepages-config tests)
- [ ] Other platformalteration tests using SampleWorkloadImage (selinux, boot-params, sysctl) should continue to work